### PR TITLE
Command-palette search with dimmed backdrop (#26)

### DIFF
--- a/apps/web-svelte/e2e/tests/transactions.spec.ts
+++ b/apps/web-svelte/e2e/tests/transactions.spec.ts
@@ -21,25 +21,30 @@ test("renders mocked transaction list", async ({ page }) => {
   await expect(desktopTable(page).getByText("Bilet miesięczny")).toBeVisible();
 });
 
-test("search filters the reusable table and toggles closed", async ({ page }) => {
-  const searchButton = page.getByRole("button", { name: "Szukaj transakcji" });
-  await searchButton.click();
+test("search filters results inside the command palette", async ({ page }) => {
+  await page.getByRole("button", { name: "Szukaj transakcji" }).click();
 
-  await page.getByPlaceholder("Szukaj transakcji…").fill("bilet");
-  await expect(desktopTable(page).getByText("Bilet miesięczny")).toBeVisible();
-  await expect(desktopTable(page).getByText("Zakupy spożywcze")).toBeHidden();
+  // The palette is a role="search" region that renders its own results table.
+  const palette = page.getByRole("search");
+  await expect(palette).toBeVisible();
 
-  await searchButton.click();
-  await expect(page.getByPlaceholder("Szukaj transakcji…")).toBeHidden();
+  await palette.getByPlaceholder("Szukaj transakcji…").fill("bilet");
+  const paletteTable = palette.locator("table");
+  await expect(paletteTable.getByText("Bilet miesięczny")).toBeVisible();
+  await expect(paletteTable.getByText("Zakupy spożywcze")).toBeHidden();
 
-  await searchButton.click();
-  await expect(page.getByPlaceholder("Szukaj transakcji…")).toBeVisible();
-
-  await desktopTable(page).getByText("Bilet miesięczny").click();
+  // Clicking a result row closes the palette and opens the detail sheet.
+  await paletteTable.getByText("Bilet miesięczny").click();
+  await expect(palette).toBeHidden();
   await expect(page.locator("aside").getByText("Bilet miesięczny")).toBeVisible();
+});
+
+test("search palette opens and closes via Escape", async ({ page }) => {
+  await page.getByRole("button", { name: "Szukaj transakcji" }).click();
+  await expect(page.getByRole("search")).toBeVisible();
 
   await page.keyboard.press("Escape");
-  await expect(page.getByPlaceholder("Szukaj transakcji…")).toBeHidden();
+  await expect(page.getByRole("search")).toBeHidden();
 });
 
 test("txId deep link opens transaction outside the current date range", async ({ page }) => {

--- a/apps/web-svelte/e2e/tests/transactions.spec.ts
+++ b/apps/web-svelte/e2e/tests/transactions.spec.ts
@@ -47,6 +47,24 @@ test("search palette opens and closes via Escape", async ({ page }) => {
   await expect(page.getByRole("search")).toBeHidden();
 });
 
+test("closing the palette clears the search query", async ({ page }) => {
+  const toggle = page.getByRole("button", { name: "Szukaj transakcji" });
+  await toggle.click();
+
+  const palette = page.getByRole("search");
+  await palette.getByPlaceholder("Szukaj transakcji…").fill("bilet");
+  await expect(palette.locator("table").getByText("Zakupy spożywcze")).toBeHidden();
+
+  // Close via the palette's ESC chip (the toggle is covered by the backdrop while open).
+  await palette.getByRole("button", { name: "Zamknij wyszukiwanie" }).click();
+  await expect(palette).toBeHidden();
+
+  // Reopen: query is reset and the full list is back — no silent filter.
+  await toggle.click();
+  await expect(palette.getByPlaceholder("Szukaj transakcji…")).toHaveValue("");
+  await expect(palette.locator("table").getByText("Zakupy spożywcze")).toBeVisible();
+});
+
 test("txId deep link opens transaction outside the current date range", async ({ page }) => {
   const oldLinkedTransaction = {
     id: "tx-old-linked",

--- a/apps/web-svelte/messages/pl.json
+++ b/apps/web-svelte/messages/pl.json
@@ -402,6 +402,8 @@
   "transactions_search_open": "Szukaj transakcji",
   "transactions_search_hint": "Wpisz, aby filtrować transakcje na liście.",
   "transactions_search_clear": "Wyczyść wyszukiwanie",
+  "transactions_search_close": "Zamknij wyszukiwanie",
+  "transactions_search_esc": "ESC",
   "transactions_date_range_label": "Zakres dat",
   "transactions_date_preset_this_month": "Ten miesiąc",
   "transactions_date_preset_last_month": "Poprzedni miesiąc",

--- a/apps/web-svelte/src/lib/components/ui/SearchModal.svelte
+++ b/apps/web-svelte/src/lib/components/ui/SearchModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Search, X } from "lucide-svelte";
-  import { tick } from "svelte";
-  import { fly } from "svelte/transition";
+  import { tick, type Snippet } from "svelte";
+  import { fade, fly } from "svelte/transition";
   import { motionDuration } from "$lib/motion";
   import * as m from "$lib/paraglide/messages";
 
@@ -10,9 +10,10 @@
     onclose: () => void;
     value: string;
     onsearchchange: (q: string) => void;
+    children?: Snippet;
   }
 
-  let { open, onclose, value, onsearchchange }: Props = $props();
+  let { open, onclose, value, onsearchchange, children }: Props = $props();
   let inputRef = $state<HTMLInputElement | null>(null);
 
   function onkeydown(e: KeyboardEvent) {
@@ -28,21 +29,30 @@
 <svelte:window {onkeydown} />
 
 {#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
-    class="pointer-events-none fixed inset-x-0 top-16 z-40 flex items-start justify-center px-4"
-    role="search"
+    class="fixed inset-0 z-40 flex items-start justify-center overflow-y-auto px-4 py-[10vh]"
+    role="presentation"
+    onclick={onclose}
   >
     <div
-      class="pointer-events-auto w-full max-w-xl overflow-hidden rounded-2xl border border-white/10 bg-slate-900/95 shadow-[0_0_60px_rgba(15,23,42,0.65)]"
+      class="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+      transition:fade={{ duration: motionDuration(160) }}
+    ></div>
+    <div
+      class="relative flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-900/95 shadow-[0_0_60px_rgba(15,23,42,0.65)]"
+      role="search"
       aria-label={m.transactions_search_open()}
       transition:fly={{ duration: motionDuration(160), y: -8 }}
+      onclick={(e) => e.stopPropagation()}
     >
-      <div class="flex items-center gap-3 px-4 py-3">
+      <div class="flex items-center gap-3 border-b border-white/5 px-4 py-3">
         <Search size={18} strokeWidth={1.8} class="shrink-0 text-slate-400" aria-hidden="true" />
         <!-- svelte-ignore a11y_autofocus -->
         <input
           bind:this={inputRef}
-          type="search"
+          type="text"
           autofocus
           {value}
           oninput={(e) => onsearchchange((e.target as HTMLInputElement).value)}
@@ -59,9 +69,17 @@
             <X size={16} strokeWidth={1.8} aria-hidden="true" />
           </button>
         {/if}
+        <button
+          type="button"
+          onclick={onclose}
+          class="shrink-0 rounded-md border border-white/10 px-2 py-1 text-xs font-medium text-slate-400 transition-colors hover:bg-white/5 hover:text-slate-200"
+          aria-label={m.transactions_search_close()}
+        >
+          {m.transactions_search_esc()}
+        </button>
       </div>
-      <div class="border-t border-white/5 px-4 py-2.5">
-        <p class="text-xs text-slate-500">{m.transactions_search_hint()}</p>
+      <div class="min-h-0 flex-1 overflow-y-auto p-2">
+        {@render children?.()}
       </div>
     </div>
   </div>

--- a/apps/web-svelte/src/routes/transactions/+page.svelte
+++ b/apps/web-svelte/src/routes/transactions/+page.svelte
@@ -216,6 +216,16 @@
   let bulkDeleteConfirm = $state(false);
   let searchModalOpen = $state(false);
 
+  function closeSearch() {
+    searchModalOpen = false;
+    searchQuery = "";
+  }
+
+  function toggleSearch() {
+    if (searchModalOpen) closeSearch();
+    else searchModalOpen = true;
+  }
+
   function onWindowKeydown(e: KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
       e.preventDefault();
@@ -435,7 +445,7 @@
     >
       <button
         type="button"
-        onclick={() => (searchModalOpen = !searchModalOpen)}
+        onclick={toggleSearch}
         class="relative hidden h-9 w-9 shrink-0 items-center justify-center rounded-full border transition-colors focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:outline-none md:flex {searchModalOpen
           ? 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200'
           : 'border-white/10 bg-slate-900/60 text-slate-300 hover:bg-white/5'}"
@@ -591,7 +601,7 @@
 </button>
 
 <button
-  onclick={() => (searchModalOpen = !searchModalOpen)}
+  onclick={toggleSearch}
   aria-label={searchModalOpen ? m.transactions_search_close() : m.transactions_search_open()}
   aria-pressed={searchModalOpen}
   class="mobile-floating-action fixed bottom-[var(--mobile-action-bottom)] left-4 z-40 flex h-14 w-14 items-center justify-center rounded-full border shadow-[0_0_24px_rgba(15,23,42,0.55)] transition-all active:scale-95 md:hidden {searchModalOpen
@@ -606,10 +616,7 @@
 
 <SearchModal
   open={searchModalOpen}
-  onclose={() => {
-    searchModalOpen = false;
-    searchQuery = "";
-  }}
+  onclose={closeSearch}
   value={searchQuery}
   onsearchchange={(q) => (searchQuery = q)}
 >
@@ -618,8 +625,7 @@
     {currentUserId}
     {emptyLabel}
     onrowclick={(tx) => {
-      searchModalOpen = false;
-      searchQuery = "";
+      closeSearch();
       sheetTx = tx;
     }}
   />

--- a/apps/web-svelte/src/routes/transactions/+page.svelte
+++ b/apps/web-svelte/src/routes/transactions/+page.svelte
@@ -436,15 +436,13 @@
       <button
         type="button"
         onclick={() => (searchModalOpen = !searchModalOpen)}
-        class="relative hidden h-9 w-9 shrink-0 items-center justify-center rounded-full border border-white/10 bg-slate-900/60 text-slate-300 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:outline-none md:flex"
-        aria-label={m.transactions_search_open()}
+        class="relative hidden h-9 w-9 shrink-0 items-center justify-center rounded-full border transition-colors focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:outline-none md:flex {searchModalOpen
+          ? 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200'
+          : 'border-white/10 bg-slate-900/60 text-slate-300 hover:bg-white/5'}"
+        aria-label={searchModalOpen ? m.transactions_search_close() : m.transactions_search_open()}
         aria-pressed={searchModalOpen}
       >
-        {#if searchModalOpen}
-          <X size={15} strokeWidth={1.9} aria-hidden="true" />
-        {:else}
-          <Search size={15} strokeWidth={1.8} aria-hidden="true" />
-        {/if}
+        <Search size={15} strokeWidth={1.8} aria-hidden="true" />
         {#if searchQuery}
           <span class="bg-accent-gradient absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full"
           ></span>
@@ -594,15 +592,13 @@
 
 <button
   onclick={() => (searchModalOpen = !searchModalOpen)}
-  aria-label={m.transactions_search_open()}
+  aria-label={searchModalOpen ? m.transactions_search_close() : m.transactions_search_open()}
   aria-pressed={searchModalOpen}
-  class="mobile-floating-action fixed bottom-[var(--mobile-action-bottom)] left-4 z-40 flex h-14 w-14 items-center justify-center rounded-full border border-white/10 bg-slate-900/90 text-slate-100 shadow-[0_0_24px_rgba(15,23,42,0.55)] transition-all active:scale-95 md:hidden"
+  class="mobile-floating-action fixed bottom-[var(--mobile-action-bottom)] left-4 z-40 flex h-14 w-14 items-center justify-center rounded-full border shadow-[0_0_24px_rgba(15,23,42,0.55)] transition-all active:scale-95 md:hidden {searchModalOpen
+    ? 'border-emerald-400/40 bg-emerald-500/20 text-emerald-200'
+    : 'border-white/10 bg-slate-900/90 text-slate-100'}"
 >
-  {#if searchModalOpen}
-    <X size={23} strokeWidth={2.1} aria-hidden="true" />
-  {:else}
-    <Search size={23} strokeWidth={2.1} aria-hidden="true" />
-  {/if}
+  <Search size={23} strokeWidth={2.1} aria-hidden="true" />
   {#if searchQuery}
     <span class="bg-accent-gradient absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full"></span>
   {/if}
@@ -610,10 +606,24 @@
 
 <SearchModal
   open={searchModalOpen}
-  onclose={() => (searchModalOpen = false)}
+  onclose={() => {
+    searchModalOpen = false;
+    searchQuery = "";
+  }}
   value={searchQuery}
   onsearchchange={(q) => (searchQuery = q)}
-/>
+>
+  <TransactionTable
+    transactions={visibleTxs ?? []}
+    {currentUserId}
+    {emptyLabel}
+    onrowclick={(tx) => {
+      searchModalOpen = false;
+      searchQuery = "";
+      sheetTx = tx;
+    }}
+  />
+</SearchModal>
 
 <TransactionDialog open={dialogOpen} onclose={() => (dialogOpen = false)} initial={editTarget} />
 


### PR DESCRIPTION
* docs(claude): truth-up handoff to merged/clean state

* feat(transactions): add ESC chip i18n keys for search palette

Adds transactions_search_esc and transactions_search_close ahead of the command-palette search redesign.



* feat(transactions): make SearchModal a dimmed command-palette shell

Backdrop dim + blur, ESC chip close affordance, results injected via a children snippet, and bordered footer hint bar removed. Input switched to type=text to drop the native webkit clear-X.



* feat(transactions): render results inside search palette + dedupe close X

Transactions table/cards now render inside the dimmed search palette via the children snippet; row click closes the palette and opens the detail sheet. Desktop toggle and mobile FAB no longer morph into a close X (handled by the palette ESC chip / Esc / backdrop) and instead show an active state when open.



* test(transactions): update search e2e for command palette

Scopes filter assertions to the palette's role=search region (the page now renders two tables while the palette is open) and covers row-click-closes + Escape close.



* fix(transactions): clear search query when palette closes

Closing the palette (ESC, backdrop, ESC chip, or selecting a row) now resets searchQuery so the underlying list is not left silently filtered with no visible search field.



---------

## Summary

-

## Why

-

## Gates

- [ ] `pnpm exec svelte-check --tsconfig ./tsconfig.json` is 0/0
- [ ] `pnpm lint` is clean
- [ ] `pnpm format:check` is clean
- [ ] `pnpm test:unit` is green
- [ ] RLS suite run if schema or policies changed
- [ ] Secret scan is clean

## Migrations

- [ ] New migration names are idempotent and not amended after apply
- [ ] RLS is enabled on new tables
- [ ] Applied migrations were not modified
- [ ] Not applicable

## Paraglide

- [ ] Recompiled Paraglide if `messages/pl.json` changed
- [ ] Not applicable

## Branch Sync

- [ ] Branch was synced from `origin/main` / `origin/dev` per `CLAUDE.md`
