### PR TITLE
fix(transactions): route toggle-close through search query reset

### DIFF
--- a/apps/web-svelte/e2e/tests/transactions.spec.ts
+++ b/apps/web-svelte/e2e/tests/transactions.spec.ts
@@ -47,6 +47,24 @@ test("search palette opens and closes via Escape", async ({ page }) => {
   await expect(page.getByRole("search")).toBeHidden();
 });
 
+test("closing the palette clears the search query", async ({ page }) => {
+  const toggle = page.getByRole("button", { name: "Szukaj transakcji" });
+  await toggle.click();
+
+  const palette = page.getByRole("search");
+  await palette.getByPlaceholder("Szukaj transakcji…").fill("bilet");
+  await expect(palette.locator("table").getByText("Zakupy spożywcze")).toBeHidden();
+
+  // Close via the palette's ESC chip (the toggle is covered by the backdrop while open).
+  await palette.getByRole("button", { name: "Zamknij wyszukiwanie" }).click();
+  await expect(palette).toBeHidden();
+
+  // Reopen: query is reset and the full list is back — no silent filter.
+  await toggle.click();
+  await expect(palette.getByPlaceholder("Szukaj transakcji…")).toHaveValue("");
+  await expect(palette.locator("table").getByText("Zakupy spożywcze")).toBeVisible();
+});
+
 test("txId deep link opens transaction outside the current date range", async ({ page }) => {
   const oldLinkedTransaction = {
     id: "tx-old-linked",

--- a/apps/web-svelte/src/routes/transactions/+page.svelte
+++ b/apps/web-svelte/src/routes/transactions/+page.svelte
@@ -216,6 +216,16 @@
   let bulkDeleteConfirm = $state(false);
   let searchModalOpen = $state(false);
 
+  function closeSearch() {
+    searchModalOpen = false;
+    searchQuery = "";
+  }
+
+  function toggleSearch() {
+    if (searchModalOpen) closeSearch();
+    else searchModalOpen = true;
+  }
+
   function onWindowKeydown(e: KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
       e.preventDefault();
@@ -435,7 +445,7 @@
     >
       <button
         type="button"
-        onclick={() => (searchModalOpen = !searchModalOpen)}
+        onclick={toggleSearch}
         class="relative hidden h-9 w-9 shrink-0 items-center justify-center rounded-full border transition-colors focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:outline-none md:flex {searchModalOpen
           ? 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200'
           : 'border-white/10 bg-slate-900/60 text-slate-300 hover:bg-white/5'}"
@@ -591,7 +601,7 @@
 </button>
 
 <button
-  onclick={() => (searchModalOpen = !searchModalOpen)}
+  onclick={toggleSearch}
   aria-label={searchModalOpen ? m.transactions_search_close() : m.transactions_search_open()}
   aria-pressed={searchModalOpen}
   class="mobile-floating-action fixed bottom-[var(--mobile-action-bottom)] left-4 z-40 flex h-14 w-14 items-center justify-center rounded-full border shadow-[0_0_24px_rgba(15,23,42,0.55)] transition-all active:scale-95 md:hidden {searchModalOpen
@@ -606,10 +616,7 @@
 
 <SearchModal
   open={searchModalOpen}
-  onclose={() => {
-    searchModalOpen = false;
-    searchQuery = "";
-  }}
+  onclose={closeSearch}
   value={searchQuery}
   onsearchchange={(q) => (searchQuery = q)}
 >
@@ -618,8 +625,7 @@
     {currentUserId}
     {emptyLabel}
     onrowclick={(tx) => {
-      searchModalOpen = false;
-      searchQuery = "";
+      closeSearch();
       sheetTx = tx;
     }}
   />


### PR DESCRIPTION
The desktop toggle and mobile FAB closed the palette by flipping searchModalOpen directly, skipping the query reset and leaving the list silently filtered (reachable via keyboard while the backdrop covers the toggle). Both now route through a shared closeSearch() helper, as does the onclose prop and row-click. Adds an e2e regression covering query reset on close.

## Summary

-

## Why

-

## Gates

- [ ] `pnpm exec svelte-check --tsconfig ./tsconfig.json` is 0/0
- [ ] `pnpm lint` is clean
- [ ] `pnpm format:check` is clean
- [ ] `pnpm test:unit` is green
- [ ] RLS suite run if schema or policies changed
- [ ] Secret scan is clean

## Migrations

- [ ] New migration names are idempotent and not amended after apply
- [ ] RLS is enabled on new tables
- [ ] Applied migrations were not modified
- [ ] Not applicable

## Paraglide

- [ ] Recompiled Paraglide if `messages/pl.json` changed
- [ ] Not applicable

## Branch Sync

- [ ] Branch was synced from `origin/main` / `origin/dev` per `CLAUDE.md`
