### PR TITLE
Add link to archived transaction in ShoppingListCard and handle query invalidation

### DIFF
--- a/apps/web-svelte/src/lib/components/shopping-lists/ShoppingListCard.svelte
+++ b/apps/web-svelte/src/lib/components/shopping-lists/ShoppingListCard.svelte
@@ -136,6 +136,15 @@
       <Pencil size={15} strokeWidth={1.8} aria-hidden="true" />
     </button>
   {/if}
+  {#if isArchived && list.linked_transaction_id}
+    <a
+      href="/transactions?txId={list.linked_transaction_id}"
+      class="flex items-center border-l border-white/5 px-3 text-xs text-emerald-400/80 transition-colors hover:bg-white/5 hover:text-emerald-300"
+      onclick={(e) => e.stopPropagation()}
+    >
+      {m.shopping_list_linked_transaction()}
+    </a>
+  {/if}
   {#if onduplicate}
     <button
       onclick={() => onduplicate(list.id)}

--- a/apps/web-svelte/src/routes/shopping-lists/+page.svelte
+++ b/apps/web-svelte/src/routes/shopping-lists/+page.svelte
@@ -151,8 +151,8 @@
   const duplicateMut = createMutation(() => ({
     mutationFn: (id: string) => duplicateShoppingList(id),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["shopping_lists"] });
       toast.success(m.toast_shopping_list_duplicated());
+      await queryClient.invalidateQueries({ queryKey: ["shopping_lists"] });
     },
     onError: () => toast.error(m.toast_error()),
   }));


### PR DESCRIPTION
…tCard and ensure query invalidation on duplicate

## Summary

-

## Why

-

## Gates

- [ ] `pnpm exec svelte-check --tsconfig ./tsconfig.json` is 0/0
- [ ] `pnpm lint` is clean
- [ ] `pnpm format:check` is clean
- [ ] `pnpm test:unit` is green
- [ ] RLS suite run if schema or policies changed
- [ ] Secret scan is clean

## Migrations

- [ ] New migration names are idempotent and not amended after apply
- [ ] RLS is enabled on new tables
- [ ] Applied migrations were not modified
- [ ] Not applicable

## Paraglide

- [ ] Recompiled Paraglide if `messages/pl.json` changed
- [ ] Not applicable

## Branch Sync

- [ ] Branch was synced from `origin/main` / `origin/dev` per `CLAUDE.md`
