### PR TITLE
feat(privacy): surface copyable user_token in notif diagnostics; fix runbook path (#81)

### DIFF
--- a/apps/web-svelte/messages/pl.json
+++ b/apps/web-svelte/messages/pl.json
@@ -615,5 +615,14 @@
   "shopping_list_planned_for_label": "Planowane: {date}",
   "shopping_list_planned_for_input_label": "Data zakupów",
   "shopping_list_planned_today": "Dzisiaj",
-  "shopping_list_planned_tomorrow": "Jutro"
+  "shopping_list_planned_tomorrow": "Jutro",
+  "admin_diag_record_title": "Diagnostyka rekordu",
+  "admin_diag_record_hint": "Dane zamaskowane do wsparcia. Brak surowych danych finansowych ani osobowych.",
+  "admin_diag_record_type_tx": "Transakcja",
+  "admin_diag_record_type_session": "Sesja importu",
+  "admin_diag_record_type_user": "Użytkownik",
+  "admin_diag_record_id_label": "ID rekordu (UUID)",
+  "admin_diag_record_search": "Szukaj",
+  "admin_diag_record_not_found": "Nie znaleziono rekordu.",
+  "admin_diag_record_error": "Błąd pobierania diagnostyki."
 }

--- a/apps/web-svelte/src/lib/components/admin/RecordDiagnosticsPanel.svelte
+++ b/apps/web-svelte/src/lib/components/admin/RecordDiagnosticsPanel.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import * as m from "$lib/paraglide/messages";
+  import {
+    fetchMaskedImportSession,
+    fetchMaskedTransaction,
+    fetchMaskedUserContext,
+  } from "$lib/services/admin-diagnostics";
+
+  type Kind = "transaction" | "session" | "user";
+  let kind = $state<Kind>("transaction");
+  let recordId = $state("");
+  let result = $state<Record<string, unknown> | null>(null);
+  let status = $state<"idle" | "loading" | "notfound" | "error">("idle");
+
+  async function search() {
+    if (!recordId.trim()) return;
+    status = "loading";
+    result = null;
+    try {
+      const data =
+        kind === "transaction"
+          ? await fetchMaskedTransaction(recordId.trim())
+          : kind === "session"
+            ? await fetchMaskedImportSession(recordId.trim())
+            : await fetchMaskedUserContext(recordId.trim());
+      if (!data) {
+        status = "notfound";
+        return;
+      }
+      result = data as unknown as Record<string, unknown>;
+      status = "idle";
+    } catch {
+      status = "error";
+    }
+  }
+
+  function isToken(key: string) {
+    return key.endsWith("_token");
+  }
+</script>
+
+<section
+  class="rounded-xl border border-amber-500/40 bg-amber-500/5 p-4"
+  aria-labelledby="diag-record-heading"
+>
+  <h2 id="diag-record-heading" class="text-lg font-semibold">
+    {m.admin_diag_record_title()}
+  </h2>
+  <p class="text-muted-foreground mt-1 text-sm">{m.admin_diag_record_hint()}</p>
+
+  <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-end">
+    <label class="flex flex-col text-sm">
+      <span class="sr-only">{m.admin_diag_record_id_label()}</span>
+      <select bind:value={kind} class="rounded-md border px-2 py-2">
+        <option value="transaction">{m.admin_diag_record_type_tx()}</option>
+        <option value="session">{m.admin_diag_record_type_session()}</option>
+        <option value="user">{m.admin_diag_record_type_user()}</option>
+      </select>
+    </label>
+    <input
+      bind:value={recordId}
+      placeholder={m.admin_diag_record_id_label()}
+      class="flex-1 rounded-md border px-3 py-2 font-mono text-sm"
+      onkeydown={(e) => e.key === "Enter" && search()}
+    />
+    <button
+      onclick={search}
+      class="bg-primary text-primary-foreground rounded-md px-4 py-2"
+      disabled={status === "loading"}
+    >
+      {m.admin_diag_record_search()}
+    </button>
+  </div>
+
+  {#if status === "notfound"}
+    <p class="text-muted-foreground mt-3 text-sm">{m.admin_diag_record_not_found()}</p>
+  {:else if status === "error"}
+    <p class="text-destructive mt-3 text-sm">{m.admin_diag_record_error()}</p>
+  {:else if result}
+    <dl class="mt-3 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
+      {#each Object.entries(result) as [key, value] (key)}
+        <dt class="text-muted-foreground font-medium">{key}</dt>
+        <dd class:font-mono={isToken(key)} class="break-all">
+          {value === null ? "—" : String(value)}
+        </dd>
+      {/each}
+    </dl>
+  {/if}
+</section>

--- a/apps/web-svelte/src/lib/services/admin-diagnostics.ts
+++ b/apps/web-svelte/src/lib/services/admin-diagnostics.ts
@@ -1,0 +1,56 @@
+import { supabase } from "$lib/supabase";
+
+export interface MaskedTransactionDiagnostics {
+  transaction_id: string;
+  user_token: string;
+  group_token: string | null;
+  category_token: string | null;
+  type: "income" | "expense";
+  status: string;
+  date_month: string;
+  amount_bucket: string;
+  currency: string;
+  description_masked: string | null;
+  merchant_token: string | null;
+  source_kind: string | null;
+  created_at: string;
+}
+
+export interface MaskedImportSessionDiagnostics {
+  session_id: string;
+  user_token: string;
+  adapter_kind: string;
+  source_kind: string;
+  status: string;
+  source_label_masked: string | null;
+  rows_total: number;
+  rows_committed: number;
+  rows_skipped: number;
+  rows_duplicate: number;
+  created_at: string;
+  committed_at: string | null;
+}
+
+export interface MaskedUserContextDiagnostics {
+  user_token: string;
+  email_masked: string | null;
+  display_name_masked: string | null;
+  role: string;
+  group_count: number;
+  created_at: string;
+}
+
+async function call<T>(fn: string, args: Record<string, string>): Promise<T | null> {
+  const { data, error } = await supabase.rpc(fn as never, args as never);
+  if (error) throw new Error(error.message);
+  return (data as T) ?? null;
+}
+
+export const fetchMaskedTransaction = (id: string) =>
+  call<MaskedTransactionDiagnostics>("admin_masked_transaction_by_id", { p_transaction_id: id });
+
+export const fetchMaskedImportSession = (id: string) =>
+  call<MaskedImportSessionDiagnostics>("admin_masked_import_session_by_id", { p_session_id: id });
+
+export const fetchMaskedUserContext = (id: string) =>
+  call<MaskedUserContextDiagnostics>("admin_masked_user_context_by_id", { p_user_id: id });

--- a/apps/web-svelte/src/lib/services/notifications.ts
+++ b/apps/web-svelte/src/lib/services/notifications.ts
@@ -15,7 +15,9 @@ export async function fetchNotifications(): Promise<Notification[]> {
 export async function fetchAdminNotifications(limit = 50): Promise<Notification[]> {
   const { data, error } = await supabase.rpc("fetch_admin_notifications", { p_limit: limit });
   if (error) throw error;
-  return (data ?? []) as Notification[];
+  // fetch_admin_notifications returns masked rows (user_token instead of user_id/data);
+  // cast via unknown since the masked shape is intentionally narrower than Notification.
+  return (data ?? []) as unknown as Notification[];
 }
 
 export async function markNotificationRead(notificationId: string): Promise<void> {

--- a/apps/web-svelte/src/lib/supabase.types.ts
+++ b/apps/web-svelte/src/lib/supabase.types.ts
@@ -903,6 +903,18 @@ export type Database = {
         Args: { p_invitation_id: string };
         Returns: undefined;
       };
+      admin_masked_import_session_by_id: {
+        Args: { p_session_id: string };
+        Returns: Json;
+      };
+      admin_masked_transaction_by_id: {
+        Args: { p_transaction_id: string };
+        Returns: Json;
+      };
+      admin_masked_user_context_by_id: {
+        Args: { p_user_id: string };
+        Returns: Json;
+      };
       assign_admin_role: { Args: { p_user_id: string }; Returns: undefined };
       attach_shopping_list_to_transaction: {
         Args: { p_list_id: string; p_tx_id: string };
@@ -1027,12 +1039,11 @@ export type Database = {
         Returns: {
           body: string;
           created_at: string;
-          data: Json;
           id: string;
           read_at: string;
           title: string;
-          type: Database["public"]["Enums"]["notification_type"];
-          user_id: string;
+          type: string;
+          user_token: string;
         }[];
       };
       fetch_admin_push_subscriptions: {
@@ -1084,6 +1095,13 @@ export type Database = {
         Args: { p_session_id: string };
         Returns: Json;
       };
+      privacy_amount_bucket: { Args: { p_amount: number }; Returns: string };
+      privacy_hmac_token: {
+        Args: { p_context: string; p_value: string };
+        Returns: string;
+      };
+      privacy_mask_email: { Args: { p_email: string }; Returns: string };
+      privacy_mask_text: { Args: { p_label: string }; Returns: string };
       process_recurring_transactions: { Args: never; Returns: undefined };
       reject_invitation: {
         Args: { p_invitation_id: string };

--- a/apps/web-svelte/src/routes/admin/+page.svelte
+++ b/apps/web-svelte/src/routes/admin/+page.svelte
@@ -10,6 +10,7 @@
   import * as m from "$lib/paraglide/messages";
   import EmptyState from "$lib/components/ui/EmptyState.svelte";
   import { Users } from "lucide-svelte";
+  import RecordDiagnosticsPanel from "$lib/components/admin/RecordDiagnosticsPanel.svelte";
 
   const queryClient = useQueryClient();
 
@@ -178,4 +179,8 @@
       </table>
     </div>
   {/if}
+
+  <div class="mt-8 border-t border-white/5 pt-6">
+    <RecordDiagnosticsPanel />
+  </div>
 </div>

--- a/apps/web-svelte/src/routes/admin/notifications/+page.svelte
+++ b/apps/web-svelte/src/routes/admin/notifications/+page.svelte
@@ -9,14 +9,23 @@
     deleteAdminPushSubscriptionByEndpoint,
     type AdminPushSubscriptionRow,
   } from "$lib/services/push";
-  import type { Notification } from "$lib/types";
   import { formatDate } from "$lib/utils";
+
+  type AdminNotificationRow = {
+    id: string;
+    user_token: string;
+    type: string;
+    title: string | null;
+    body: string | null;
+    read_at: string | null;
+    created_at: string;
+  };
   import { createMutation } from "@tanstack/svelte-query";
   import { toast } from "svelte-sonner";
   import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
   import * as m from "$lib/paraglide/messages";
 
-  let notifications = $state<Notification[]>([]);
+  let notifications = $state<AdminNotificationRow[]>([]);
   let pushSubs = $state<AdminPushSubscriptionRow[]>([]);
   let loading = $state(true);
   let error = $state<string | null>(null);
@@ -45,7 +54,7 @@
         fetchAdminNotifications(),
         fetchAdminPushSubscriptions(),
       ]);
-      notifications = notifs;
+      notifications = notifs as unknown as AdminNotificationRow[];
       pushSubs = subs;
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);

--- a/apps/web-svelte/src/routes/admin/notifications/+page.svelte
+++ b/apps/web-svelte/src/routes/admin/notifications/+page.svelte
@@ -195,6 +195,14 @@
               <p class="text-xs text-slate-500">
                 {n.type}{n.read_at ? "" : " · unread"}
               </p>
+              <button
+                type="button"
+                title={n.user_token}
+                onclick={() => navigator.clipboard?.writeText(n.user_token)}
+                class="font-mono text-xs text-slate-600 hover:text-slate-400"
+              >
+                user: {n.user_token.slice(0, 12)}…
+              </button>
             </li>
           {/each}
         </ul>

--- a/apps/web-svelte/tests/rls/notifications.spec.ts
+++ b/apps/web-svelte/tests/rls/notifications.spec.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   SENTINEL,
   cleanupSentinels,
+  createUserClient,
   expectBlockedWrite,
   provisionTwoUsers,
   type TestContext,
@@ -75,5 +76,34 @@ describe("RLS: notifications", () => {
     const { error } = await ctx.userA.client.rpc("fetch_admin_notifications", { p_limit: 10 });
     expect(error).not.toBeNull();
     expect(String(error?.message ?? "")).toMatch(/permission_denied/);
+  });
+
+  it("masks notification title/body and returns user_token", async () => {
+    const { data: inserted, error: insertError } = await ctx.admin
+      .from("notifications")
+      .insert({
+        user_id: ctx.userB.userId,
+        type: "transaction_summary",
+        title: "__SECRET_TITLE__",
+        body: "__SECRET_BODY_120PLN__",
+      })
+      .select("id")
+      .single();
+    if (insertError) throw insertError;
+    const insertedId = (inserted as { id: string }).id;
+    await ctx.admin.from("profiles").update({ role: "admin" }).eq("id", ctx.userA.userId);
+    const asAdmin = createUserClient(ctx.userA.accessToken);
+    const { data, error } = await asAdmin.rpc("fetch_admin_notifications", { p_limit: 50 });
+    await ctx.admin.from("profiles").update({ role: "user" }).eq("id", ctx.userA.userId);
+    // cleanup inserted notification
+    await ctx.admin.from("notifications").delete().eq("id", insertedId);
+    expect(error).toBeNull();
+    const json = JSON.stringify(data);
+    expect(json).not.toContain("__SECRET_TITLE__");
+    expect(json).not.toContain("__SECRET_BODY_120PLN__");
+    const row = (data as Array<Record<string, unknown>>).find((r) => r.id === insertedId);
+    expect(row?.title).toBe("[masked]");
+    expect(row?.body).toBe("[masked]");
+    expect(String(row?.user_token)).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
+++ b/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
@@ -183,3 +183,44 @@ describe("admin masked diagnostics: transaction", () => {
     expect(data.category_token).not.toBe(data.group_token);
   });
 });
+
+describe("admin masked diagnostics: import session", () => {
+  let ctx: TestContext;
+  let seeded: Seeded;
+  let asAdmin: SupabaseClient;
+
+  beforeAll(async () => {
+    ctx = await provisionTwoUsers();
+    await cleanupSeed(ctx.admin, ctx.userB.userId); // defensive: auth users persist across db reset
+    seeded = await seedImportedTransaction(ctx.admin, ctx.userB.userId);
+    asAdmin = await adminClientFor(ctx);
+  });
+  afterAll(async () => {
+    await ctx.admin.from("profiles").update({ role: "user" }).eq("id", ctx.userA.userId);
+    await cleanupSeed(ctx.admin, ctx.userB.userId);
+  });
+
+  it("denies non-admin", async () => {
+    const { error } = await ctx.userB.client.rpc("admin_masked_import_session_by_id", {
+      p_session_id: seeded.sessionId,
+    });
+    expect(String(error?.message ?? "")).toMatch(/permission_denied/);
+  });
+
+  it("returns counts + masked label, no raw provenance", async () => {
+    const { data, error } = await asAdmin.rpc("admin_masked_import_session_by_id", {
+      p_session_id: seeded.sessionId,
+    });
+    expect(error).toBeNull();
+    const json = JSON.stringify(data);
+    expect(json).not.toContain(S.filename);
+    expect(json).not.toContain("hash_" + S.filename);
+    expect(json).not.toContain(S.accountLabel);
+    expect(data.source_label_masked).toBe("[masked]");
+    expect(data.adapter_kind).toBe("mbank");
+    expect(data.source_kind).toBe("bank_statement");
+    expect(data.rows_total).toBe(1);
+    expect(data.rows_committed).toBe(1);
+    expect(data.user_token).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
+++ b/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
@@ -1,0 +1,185 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createUserClient, provisionTwoUsers, type TestContext } from "./setup";
+
+const S = {
+  merchant: "__SECRET_MERCHANT_81__",
+  desc: "__SECRET_DESC_81__",
+  filename: "__secret_file_81__.csv",
+  accountLabel: "__SECRET_ACCOUNT_81__",
+  amount: 1234.56, // -> '> 1000 PLN'
+};
+
+type Seeded = {
+  transactionId: string;
+  sessionId: string;
+  categoryId: string;
+  groupId: string;
+};
+
+async function seedImportedTransaction(
+  admin: SupabaseClient,
+  userId: string,
+): Promise<Seeded> {
+  const { data: cat } = await admin
+    .from("categories")
+    .insert({ user_id: userId, name: S.desc + "_CAT", type: "expense" })
+    .select("id")
+    .single()
+    .throwOnError();
+  const { data: grp } = await admin
+    .from("user_groups")
+    .insert({ name: S.desc + "_GRP", owner_id: userId })
+    .select("id")
+    .single()
+    .throwOnError();
+  const { data: acct } = await admin
+    .from("bank_accounts")
+    .insert({ user_id: userId, kind: "mbank", label: S.accountLabel })
+    .select("id")
+    .single()
+    .throwOnError();
+  const { data: tx } = await admin
+    .from("transactions")
+    .insert({
+      user_id: userId,
+      group_id: grp!.id,
+      category_id: cat!.id,
+      amount: S.amount,
+      currency: "PLN",
+      description: S.desc,
+      date: new Date().toISOString(),
+      type: "expense",
+      status: "paid",
+    })
+    .select("id")
+    .single()
+    .throwOnError();
+  const { data: sess } = await admin
+    .from("transaction_import_sessions")
+    .insert({
+      user_id: userId,
+      bank_account_id: acct!.id,
+      source_filename: S.filename,
+      source_file_hash: "hash_" + S.filename,
+      detected_kind: "mbank",
+      adapter_kind: "mbank",
+      source_kind: "bank_statement",
+      status: "committed",
+      rows_total: 1,
+      rows_committed: 1,
+    })
+    .select("id")
+    .single()
+    .throwOnError();
+  const { data: row } = await admin
+    .from("transaction_import_rows")
+    .insert({
+      session_id: sess!.id,
+      row_index: 0,
+      posted_at: new Date().toISOString().slice(0, 10),
+      amount: S.amount,
+      type: "expense",
+      description: S.desc,
+      counterparty: S.merchant,
+      currency: "PLN",
+      raw_row_hash: "rrh_0",
+      decision: "import",
+      transaction_id: tx!.id,
+    })
+    .select("id")
+    .single()
+    .throwOnError();
+  await admin
+    .from("transaction_import_links")
+    .insert({
+      transaction_id: tx!.id,
+      user_id: userId,
+      bank_account_id: acct!.id,
+      session_id: sess!.id,
+      row_id: row!.id,
+      source_file_hash: "hash_" + S.filename,
+      source_row_index: 0,
+      fingerprint: "fp_0",
+    })
+    .throwOnError();
+  return { transactionId: tx!.id, sessionId: sess!.id, categoryId: cat!.id, groupId: grp!.id };
+}
+
+async function cleanupSeed(admin: SupabaseClient, userId: string) {
+  // FK chain is ON DELETE RESTRICT: links -> rows -> sessions -> bank_accounts.
+  // Delete in dependency order: links restrict rows/sessions/accounts; rows restrict sessions.
+  const { data: sessions } = await admin
+    .from("transaction_import_sessions")
+    .select("id")
+    .eq("user_id", userId);
+  const sessionIds = (sessions ?? []).map((s) => s.id);
+  await admin.from("transaction_import_links").delete().eq("user_id", userId);
+  if (sessionIds.length) {
+    await admin.from("transaction_import_rows").delete().in("session_id", sessionIds);
+  }
+  await admin.from("transaction_import_sessions").delete().eq("user_id", userId);
+  await admin.from("transactions").delete().eq("user_id", userId);
+  await admin.from("bank_accounts").delete().eq("user_id", userId);
+  await admin.from("user_groups").delete().eq("owner_id", userId);
+  await admin.from("categories").delete().eq("user_id", userId).like("name", "__SECRET%");
+}
+
+async function adminClientFor(ctx: TestContext): Promise<SupabaseClient> {
+  await ctx.admin.from("profiles").update({ role: "admin" }).eq("id", ctx.userA.userId);
+  return createUserClient(ctx.userA.accessToken);
+}
+
+describe("admin masked diagnostics: transaction", () => {
+  let ctx: TestContext;
+  let seeded: Seeded;
+  let asAdmin: SupabaseClient;
+
+  beforeAll(async () => {
+    ctx = await provisionTwoUsers();
+    await cleanupSeed(ctx.admin, ctx.userB.userId); // defensive: auth users persist across db reset
+    seeded = await seedImportedTransaction(ctx.admin, ctx.userB.userId);
+    asAdmin = await adminClientFor(ctx);
+  });
+
+  afterAll(async () => {
+    await ctx.admin.from("profiles").update({ role: "user" }).eq("id", ctx.userA.userId);
+    await cleanupSeed(ctx.admin, ctx.userB.userId);
+  });
+
+  it("denies non-admin", async () => {
+    const { error } = await ctx.userB.client.rpc("admin_masked_transaction_by_id", {
+      p_transaction_id: seeded.transactionId,
+    });
+    expect(error).not.toBeNull();
+    expect(String(error?.message ?? "")).toMatch(/permission_denied/);
+  });
+
+  it("returns masked fields with no raw sentinels", async () => {
+    const { data, error } = await asAdmin.rpc("admin_masked_transaction_by_id", {
+      p_transaction_id: seeded.transactionId,
+    });
+    expect(error).toBeNull();
+    const json = JSON.stringify(data);
+    expect(json).not.toContain(S.merchant);
+    expect(json).not.toContain(S.desc);
+    expect(json).not.toContain(S.filename);
+    expect(json).not.toContain(S.accountLabel);
+    expect(json).not.toContain("1234.56");
+    expect(data.description_masked).toBe("[masked]");
+    expect(data.amount_bucket).toBe("> 1000 PLN");
+    expect(data.type).toBe("expense");
+    expect(data.currency).toBe("PLN");
+    expect(data.source_kind).toBe("bank_statement");
+    expect(data.user_token).toMatch(/^[0-9a-f]{64}$/);
+    expect(data.merchant_token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("uses context separation: user vs merchant token differ for same input class", async () => {
+    const { data } = await asAdmin.rpc("admin_masked_transaction_by_id", {
+      p_transaction_id: seeded.transactionId,
+    });
+    expect(data.user_token).not.toBe(data.merchant_token);
+    expect(data.category_token).not.toBe(data.group_token);
+  });
+});

--- a/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
+++ b/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createUserClient, provisionTwoUsers, type TestContext } from "./setup";
@@ -267,5 +268,87 @@ describe("admin masked diagnostics: user context", () => {
     });
     expect(u.data.user_token).toBe(t.data.user_token);
     await cleanupSeed(ctx.admin, ctx.userB.userId);
+  });
+});
+
+const LOCAL_DB_URL =
+  process.env.SUPABASE_DB_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+describe("privacy primitives: fail-closed", () => {
+  it("privacy_hmac_token raises when pepper missing (rolled back)", () => {
+    // One transaction: remove pepper, call fn (must error), always ROLLBACK.
+    // ON_ERROR_STOP aborts on the raise; the uncommitted tx is rolled back on
+    // disconnect, so the pepper delete never persists.
+    const sql =
+      "begin; delete from vault.secrets where name='privacy_pepper'; " +
+      "select privacy_hmac_token('x','user'); rollback;";
+    let threw = false;
+    try {
+      execSync(`psql "${LOCAL_DB_URL}" -v ON_ERROR_STOP=1 -c "${sql}"`, {
+        stdio: "pipe",
+      });
+    } catch (e) {
+      threw = true;
+      expect(String((e as { stderr?: Buffer }).stderr ?? e)).toMatch(/fail closed/);
+    }
+    expect(threw).toBe(true);
+  });
+
+  it("pepper still present after the rolled-back failure test", () => {
+    const out = execSync(
+      `psql "${LOCAL_DB_URL}" -t -A -c "select count(*) from vault.secrets where name='privacy_pepper'"`,
+      { encoding: "utf8" },
+    ).trim();
+    expect(out).toBe("1");
+  });
+});
+
+describe("amount bucket boundaries (via transaction RPC)", () => {
+  let ctx: TestContext;
+  let asAdmin: SupabaseClient;
+  beforeAll(async () => {
+    ctx = await provisionTwoUsers();
+    await cleanupSeed(ctx.admin, ctx.userB.userId);
+    asAdmin = await adminClientFor(ctx);
+  });
+  afterAll(async () => {
+    await ctx.admin.from("profiles").update({ role: "user" }).eq("id", ctx.userA.userId);
+    await cleanupSeed(ctx.admin, ctx.userB.userId);
+  });
+
+  const cases: Array<[number, string]> = [
+    [49.99, "< 50 PLN"],
+    [50, "50-200 PLN"],
+    [200, "200-1000 PLN"],
+    [1000, "> 1000 PLN"],
+  ];
+
+  it.each(cases)("amount %s -> %s", async (amount, bucket) => {
+    const { data: cat } = await ctx.admin
+      .from("categories")
+      .insert({ user_id: ctx.userB.userId, name: "__SECRET_BKT__" + amount, type: "expense" })
+      .select("id")
+      .single()
+      .throwOnError();
+    const { data: tx } = await ctx.admin
+      .from("transactions")
+      .insert({
+        user_id: ctx.userB.userId,
+        category_id: cat!.id,
+        amount,
+        currency: "PLN",
+        description: "__SECRET_DESC_81__",
+        date: new Date().toISOString(),
+        type: "expense",
+        status: "paid",
+      })
+      .select("id")
+      .single()
+      .throwOnError();
+    const { data } = await asAdmin.rpc("admin_masked_transaction_by_id", {
+      p_transaction_id: tx!.id,
+    });
+    expect(data.amount_bucket).toBe(bucket);
   });
 });

--- a/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
+++ b/apps/web-svelte/tests/rls/privacy_diagnostics.spec.ts
@@ -224,3 +224,48 @@ describe("admin masked diagnostics: import session", () => {
     expect(data.user_token).toMatch(/^[0-9a-f]{64}$/);
   });
 });
+
+describe("admin masked diagnostics: user context", () => {
+  let ctx: TestContext;
+  let asAdmin: SupabaseClient;
+
+  beforeAll(async () => {
+    ctx = await provisionTwoUsers();
+    asAdmin = await adminClientFor(ctx);
+  });
+  afterAll(async () => {
+    await ctx.admin.from("profiles").update({ role: "user" }).eq("id", ctx.userA.userId);
+    await cleanupSeed(ctx.admin, ctx.userB.userId);
+  });
+
+  it("denies non-admin", async () => {
+    const { error } = await ctx.userB.client.rpc("admin_masked_user_context_by_id", {
+      p_user_id: ctx.userB.userId,
+    });
+    expect(String(error?.message ?? "")).toMatch(/permission_denied/);
+  });
+
+  it("returns masked email + user_token, no raw email", async () => {
+    const { data, error } = await asAdmin.rpc("admin_masked_user_context_by_id", {
+      p_user_id: ctx.userB.userId,
+    });
+    expect(error).toBeNull();
+    const json = JSON.stringify(data);
+    expect(json).not.toContain(ctx.userB.email); // raw email never present
+    expect(data.email_masked).toMatch(/^.\*\*\*@/);
+    expect(data.user_token).toMatch(/^[0-9a-f]{64}$/);
+    expect(typeof data.group_count).toBe("number");
+  });
+
+  it("same user_token across record types (stable correlation)", async () => {
+    const u = await asAdmin.rpc("admin_masked_user_context_by_id", {
+      p_user_id: ctx.userB.userId,
+    });
+    const seeded = await seedImportedTransaction(ctx.admin, ctx.userB.userId);
+    const t = await asAdmin.rpc("admin_masked_transaction_by_id", {
+      p_transaction_id: seeded.transactionId,
+    });
+    expect(u.data.user_token).toBe(t.data.user_token);
+    await cleanupSeed(ctx.admin, ctx.userB.userId);
+  });
+});

--- a/apps/web-svelte/tests/services/admin-diagnostics.spec.ts
+++ b/apps/web-svelte/tests/services/admin-diagnostics.spec.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpc = vi.fn();
+vi.mock("$lib/supabase", () => ({ supabase: { rpc: (...a: unknown[]) => rpc(...a) } }));
+
+import {
+  fetchMaskedTransaction,
+  fetchMaskedImportSession,
+  fetchMaskedUserContext,
+} from "$lib/services/admin-diagnostics";
+
+describe("admin-diagnostics service", () => {
+  beforeEach(() => rpc.mockReset());
+
+  it("calls the transaction RPC with the id and returns data", async () => {
+    rpc.mockResolvedValue({ data: { transaction_id: "t1", amount_bucket: "< 50 PLN" }, error: null });
+    const r = await fetchMaskedTransaction("t1");
+    expect(rpc).toHaveBeenCalledWith("admin_masked_transaction_by_id", { p_transaction_id: "t1" });
+    expect(r?.amount_bucket).toBe("< 50 PLN");
+  });
+
+  it("throws on RPC error", async () => {
+    rpc.mockResolvedValue({ data: null, error: { message: "permission_denied" } });
+    await expect(fetchMaskedUserContext("u1")).rejects.toThrow(/permission_denied/);
+  });
+
+  it("maps session + user RPC names", async () => {
+    rpc.mockResolvedValue({ data: {}, error: null });
+    await fetchMaskedImportSession("s1");
+    expect(rpc).toHaveBeenCalledWith("admin_masked_import_session_by_id", { p_session_id: "s1" });
+    await fetchMaskedUserContext("u1");
+    expect(rpc).toHaveBeenCalledWith("admin_masked_user_context_by_id", { p_user_id: "u1" });
+  });
+});

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -512,6 +512,18 @@ All SECURITY DEFINER (bypass RLS) unless marked SECURITY INVOKER. Defined in `20
 | `revoke_admin_role(p_user_id)` | admin | Cannot revoke self.                                |
 | `trigger_admin_summary()`      | admin | Manually fires `send-admin-summary` Edge Function. |
 
+**Admin diagnostics — masked cross-user reads (issue #81)**
+
+`admin_masked_transaction_by_id` / `admin_masked_import_session_by_id` /
+`admin_masked_user_context_by_id` are the only deliberate admin cross-user
+financial reads. They return only masked/bucketed fields plus keyed-HMAC tokens
+(pepper stored in Supabase Vault, never reaches the client) — never raw
+financial or personal data. `fetch_admin_notifications` is likewise masked
+(title/body → `[masked]`, returns `user_token` not raw `user_id`). No
+`is_admin()` bypass RLS exists on `transactions` or import tables. See
+[`docs/architecture/flows/admin-diagnostics-privacy.md`](flows/admin-diagnostics-privacy.md)
+for the full model and threat scope.
+
 **Account**
 
 | RPC                | Auth | Behavior                               |

--- a/docs/architecture/flows/admin-diagnostics-privacy.md
+++ b/docs/architecture/flows/admin-diagnostics-privacy.md
@@ -1,0 +1,38 @@
+# Admin Diagnostics Privacy
+
+**This is pseudonymisation + masking, NOT anonymisation.** A record retrievable
+by ID and tied to an account is not anonymous. The goal: make re-identification
+impossible from the admin/support surface alone — not against a DB superuser or
+a leaked pepper.
+
+## Model
+
+- Admins look up transactions, import sessions, and user context **by ID** via
+  three `security definer` RPCs (`admin_masked_*`), each guarded by `is_admin()`.
+- Correlation uses keyed HMAC tokens computed on-read: `privacy_hmac_token(value,
+  context)` = `hex(hmac(context || ':' || lower(trim(value)), privacy_pepper,
+  'sha256'))`. The pepper lives in Supabase Vault and never reaches the client.
+- **Context separation:** fixed contexts (`user`, `merchant`, `group`,
+  `category`, `email`, `import_source`) prevent the same string correlating
+  across field types.
+- Amounts are bucketed (`< 50 / 50-200 / 200-1000 / > 1000 PLN`); descriptions,
+  names, labels are masked (`[masked]`); emails masked (`a***@domain`).
+- `privacy_hmac_token` **fails closed**: it raises if the pepper is missing and
+  rejects unknown contexts. Helper functions are revoked from all client roles
+  (`public, anon, authenticated, service_role`) — callable only by the
+  SECURITY DEFINER RPCs.
+
+## Boundary
+
+The masked RPCs are the only deliberate admin cross-user financial path. No
+`is_admin()` bypass RLS exists on `transactions` / import tables. `fetch_admin_notifications`
+is masked (title/body → `[masked]`) and returns `user_token`, not raw `user_id`.
+
+## Threat model
+
+In scope: stop routine admin/support UI from exposing raw financial/personal
+data; make masked records irreversible without the pepper; allow by-ID debugging
++ stable pseudonymous correlation.
+
+Out of scope: production DB superuser, leaked pepper, full client-side
+encryption, reversible admin decryption.

--- a/docs/architecture/flows/admin-diagnostics-privacy.md
+++ b/docs/architecture/flows/admin-diagnostics-privacy.md
@@ -5,13 +5,40 @@ by ID and tied to an account is not anonymous. The goal: make re-identification
 impossible from the admin/support surface alone — not against a DB superuser or
 a leaked pepper.
 
+## What this is — and is not
+
+This is **privacy Layer 1 of 3: masked admin/support diagnostics.** It is NOT
+database encryption and NOT operational access lockdown. Frame it accurately:
+
+> Support and admin diagnostics are privacy-preserving: sensitive financial
+> details are masked and records are correlated with pseudonymous tokens. Raw
+> financial data is not exposed in admin tools.
+
+Do **not** market this as "database data is encrypted from admins." Anyone with
+Supabase project-owner access or direct DB credentials can still read raw tables
+— that is Layer 2/3 territory (below).
+
+## Three privacy layers
+
+1. **Masked admin access — DONE (this work).** Admin tools use masked RPCs, not
+   raw table reads. Solves: normal admin UI / support diagnostics no longer
+   expose raw financial data.
+2. **Operational access lockdown — NOT in this work (operational).** Admins
+   should not have routine SQL/dashboard access to raw production tables. Solved
+   operationally, not in code: limit Supabase project access, no shared
+   service-role keys, audit admin access, least privilege, and do not build raw
+   lookup admin screens.
+3. **Sensitive-column encryption — FUTURE (separate track).** Store the
+   highest-risk values encrypted so even direct DB reads show ciphertext without
+   the key. Deliberately deferred — see roadmap below.
+
 ## Model
 
 - Admins look up transactions, import sessions, and user context **by ID** via
   three `security definer` RPCs (`admin_masked_*`), each guarded by `is_admin()`.
 - Correlation uses keyed HMAC tokens computed on-read: `privacy_hmac_token(value,
-  context)` = `hex(hmac(context || ':' || lower(trim(value)), privacy_pepper,
-  'sha256'))`. The pepper lives in Supabase Vault and never reaches the client.
+context)` = `hex(hmac(context || ':' || lower(trim(value)), privacy_pepper,
+'sha256'))`. The pepper lives in Supabase Vault and never reaches the client.
 - **Context separation:** fixed contexts (`user`, `merchant`, `group`,
   `category`, `email`, `import_source`) prevent the same string correlating
   across field types.
@@ -32,7 +59,33 @@ is masked (title/body → `[masked]`) and returns `user_token`, not raw `user_id
 
 In scope: stop routine admin/support UI from exposing raw financial/personal
 data; make masked records irreversible without the pepper; allow by-ID debugging
-+ stable pseudonymous correlation.
+
+- stable pseudonymous correlation.
 
 Out of scope: production DB superuser, leaked pepper, full client-side
 encryption, reversible admin decryption.
+
+## Encryption roadmap (future — Layer 3)
+
+Do **not** jump to full column encryption for MVP. It affects search, filtering,
+categorization, imports, duplicate detection, debugging, backups, migrations, and
+support. Portfelik's deterministic categorization and import matching need
+readable descriptions/counterparties somewhere; encrypting those naively breaks
+core product logic. Encrypt selectively, highest-risk fields first, and only
+after designing search/categorization around it.
+
+**Candidates to encrypt first** (low product-logic coupling):
+
+- `transaction_import_sessions.source_filename`
+- `bank_accounts.label`
+- raw import-row payloads / descriptions if retained
+- notification `title` / `body` when they can contain amounts or merchants
+- `transactions.description` — only after redesigning search/categorization around it
+
+**Do NOT encrypt first** (needed for summaries, dashboards, filtering, reports,
+RLS): `amount`, `date`, `type`, `status`, `category_id`, `user_id`.
+
+**Sequencing:** keep the masked admin RPCs (Layer 1) → publish the privacy
+statement above → lock down operational production-DB access (Layer 2) → then
+selectively encrypt the highest-risk fields (Layer 3). Treat Layer 3 as a
+separate, deeper security track, not an MVP blocker.

--- a/docs/architecture/flows/admin-diagnostics-privacy.md
+++ b/docs/architecture/flows/admin-diagnostics-privacy.md
@@ -89,3 +89,40 @@ RLS): `amount`, `date`, `type`, `status`, `category_id`, `user_id`.
 statement above → lock down operational production-DB access (Layer 2) → then
 selectively encrypt the highest-risk fields (Layer 3). Treat Layer 3 as a
 separate, deeper security track, not an MVP blocker.
+
+## Beta trust posture
+
+Honest trust level for using **real** transaction/import data:
+
+- **OK for:** the owner, close collaborators, trusted early testers — people who
+  understand this is beta software.
+- **Not yet ideal for:** broad public onboarding of highly privacy-sensitive
+  users, until privacy policy, access controls, operational process,
+  deletion/export, and incident posture are all clear.
+
+**The app is NOT end-to-end encrypted.** Raw data exists in the production
+database because the product needs it for imports, categorization, summaries,
+dashboards, and future plan matching. A database owner / service-role holder /
+production operator can technically access it. Protection is account-level
+access control + privacy-preserving admin tooling + operational restriction —
+**not** cryptographic hiding from the operator.
+
+User-facing wording to use (do not overpromise "no one can ever see your data"):
+
+> Your data is protected by account-level access controls. Admin/support tools
+> are privacy-preserving and show masked diagnostic data. Raw financial data is
+> not exposed through normal admin screens. Production database access is
+> restricted to operators who need it. The app is beta and not end-to-end
+> encrypted.
+
+### Pre-beta readiness checklist
+
+- [x] RLS suite green (account-level isolation).
+- [x] Admin UI shows no raw financial details (Layer 1, this work).
+- [x] Users can delete their account/data (`delete_account()` RPC + Settings → Profile).
+- [ ] Production Supabase access limited to owner / essential operators (Layer 2, operational).
+- [ ] Service-role keys not exposed anywhere client-side (verify; never ship in client bundle).
+- [ ] Privacy policy states what is stored and who can access it.
+- [ ] Full account-data export (CSV transaction export exists; full export is a gap).
+- [ ] Onboarding asks testers to upload only the history they need.
+- [ ] Beta + "not end-to-end encrypted" communicated to testers.

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -129,6 +129,33 @@ If a rotation broke push end-to-end:
 2. If VAPID was rotated and subscriptions wiped, users must re-subscribe - there is no path to restore the deleted rows. Plan rotations during low-engagement windows.
 3. If `INTERNAL_TRIGGER_SECRET` mismatch caused weekly-summary failures, manually fire `process_recurring_transactions()` and the summary RPC after restoring.
 
+## Rotate `privacy_pepper`
+
+Used by the admin-diagnostics masking layer (issue #81). HMAC pepper stored in
+Supabase Vault; never exposed to the client. Rotation invalidates all previously
+shown diagnostic tokens — this is acceptable because tokens are diagnostic-only
+and never stored. Correlation simply restarts under the new pepper; no data
+migration is needed.
+
+1. Update the Vault secret (via Supabase Dashboard SQL Editor or MCP `execute_sql`):
+   ```sql
+   select vault.update_secret(
+     (select id from vault.secrets where name = 'privacy_pepper'),
+     encode(extensions.gen_random_bytes(32), 'hex')
+   );
+   ```
+2. No Edge Function or client changes required — the pepper is read on-query by the SECURITY DEFINER RPCs.
+3. **Verify** by calling one of the masked RPCs from `/admin/diagnostics` and confirming the returned `user_token` differs from any previously recorded value.
+
+> **Note:** if the `privacy_pepper` secret is missing (e.g. new environment), seed it:
+> ```sql
+> select vault.create_secret(
+>   encode(extensions.gen_random_bytes(32), 'hex'),
+>   'privacy_pepper',
+>   'HMAC pepper for admin diagnostics pseudonymisation (issue #81)'
+> );
+> ```
+
 ## References
 
 - `supabase/migrations/20260425000001_phase5_2_edge_function_hooks.sql` - DB triggers using `internal_trigger_secret`.

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -5,12 +5,12 @@ Last updated: 2026-06-04
 Covers rotation of the four secrets that gate push notifications and internal
 Edge Function calls in Portfelik.
 
-| Secret | Where it lives | Used by | Rotation impact |
-|---|---|---|---|
-| `internal_trigger_secret` | Supabase Vault (`vault.create_secret`) + Edge Function secrets | DB triggers/cron jobs that POST to Edge Functions; Edge Functions verify the internal secret | Internal triggers fail until both sides are updated. No user-visible impact if done in the same window. |
-| `VAPID_PRIVATE_KEY` | Edge Function secrets (`send-push`) | Signs web-push messages | Existing browser subscriptions stay valid only if the *public* key did not change. Pair with public-key rotation only when subscriptions need to be invalidated. |
-| `VAPID_PUBLIC_KEY` | Edge Function secrets + `apps/web-svelte/.env.production` (build-time `PUBLIC_VAPID_KEY`) | Browser `pushManager.subscribe({ applicationServerKey })`; passed to `urlBase64ToUint8Array` in `services/push.ts` | All existing `push_subscriptions` rows become invalid. Browsers re-subscribe on next visit; users who never return are silently dropped. |
-| `VAPID_SUBJECT` | Edge Function secrets | `web-push` library header (`mailto:` or HTTPS URL identifying the sender) | None on existing subscriptions; only future sends use the new value. Safe to rotate any time. |
+| Secret                    | Where it lives                                                                            | Used by                                                                                                            | Rotation impact                                                                                                                                                  |
+| ------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `internal_trigger_secret` | Supabase Vault (`vault.create_secret`) + Edge Function secrets                            | DB triggers/cron jobs that POST to Edge Functions; Edge Functions verify the internal secret                       | Internal triggers fail until both sides are updated. No user-visible impact if done in the same window.                                                          |
+| `VAPID_PRIVATE_KEY`       | Edge Function secrets (`send-push`)                                                       | Signs web-push messages                                                                                            | Existing browser subscriptions stay valid only if the _public_ key did not change. Pair with public-key rotation only when subscriptions need to be invalidated. |
+| `VAPID_PUBLIC_KEY`        | Edge Function secrets + `apps/web-svelte/.env.production` (build-time `PUBLIC_VAPID_KEY`) | Browser `pushManager.subscribe({ applicationServerKey })`; passed to `urlBase64ToUint8Array` in `services/push.ts` | All existing `push_subscriptions` rows become invalid. Browsers re-subscribe on next visit; users who never return are silently dropped.                         |
+| `VAPID_SUBJECT`           | Edge Function secrets                                                                     | `web-push` library header (`mailto:` or HTTPS URL identifying the sender)                                          | None on existing subscriptions; only future sends use the new value. Safe to rotate any time.                                                                    |
 
 ## When to rotate
 
@@ -145,9 +145,10 @@ migration is needed.
    );
    ```
 2. No Edge Function or client changes required — the pepper is read on-query by the SECURITY DEFINER RPCs.
-3. **Verify** by calling one of the masked RPCs from `/admin/diagnostics` and confirming the returned `user_token` differs from any previously recorded value.
+3. **Verify** by calling one of the masked RPCs from the record-diagnostics panel on `/admin` and confirming the returned `user_token` differs from any previously recorded value.
 
 > **Note:** if the `privacy_pepper` secret is missing (e.g. new environment), seed it:
+>
 > ```sql
 > select vault.create_secret(
 >   encode(extensions.gen_random_bytes(32), 'hex'),

--- a/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
+++ b/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
@@ -156,3 +156,39 @@ begin
 end $$;
 
 grant execute on function admin_masked_import_session_by_id(uuid) to authenticated;
+
+-- ── 5. Masked diagnostic RPC: user context ────────────────────────────────────
+create or replace function admin_masked_user_context_by_id(p_user_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, vault, extensions
+as $$
+declare
+  v_email       text;
+  v_name        text;
+  v_role        text;
+  v_created     timestamptz;
+  v_group_count int;
+begin
+  if not is_admin() then
+    raise exception 'permission_denied: admin only' using errcode = '42501';
+  end if;
+  select email, name, role, created_at
+    into v_email, v_name, v_role, v_created
+    from profiles where id = p_user_id;
+  if v_role is null then
+    return null;
+  end if;
+  select count(*) into v_group_count from group_members where user_id = p_user_id;
+  return jsonb_build_object(
+    'user_token',          privacy_hmac_token(p_user_id::text, 'user'),
+    'email_masked',        privacy_mask_email(v_email),
+    'display_name_masked', privacy_mask_text(v_name),
+    'role',                v_role,
+    'group_count',         v_group_count,
+    'created_at',          v_created
+  );
+end $$;
+
+grant execute on function admin_masked_user_context_by_id(uuid) to authenticated;

--- a/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
+++ b/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
@@ -119,3 +119,40 @@ begin
 end $$;
 
 grant execute on function admin_masked_transaction_by_id(uuid) to authenticated;
+
+-- ── 4. Masked diagnostic RPC: import session ──────────────────────────────────
+create or replace function admin_masked_import_session_by_id(p_session_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, vault, extensions
+as $$
+declare
+  v_s     transaction_import_sessions%rowtype;
+  v_label text;
+begin
+  if not is_admin() then
+    raise exception 'permission_denied: admin only' using errcode = '42501';
+  end if;
+  select * into v_s from transaction_import_sessions where id = p_session_id;
+  if not found then
+    return null;
+  end if;
+  select label into v_label from bank_accounts where id = v_s.bank_account_id;
+  return jsonb_build_object(
+    'session_id',          v_s.id,
+    'user_token',          privacy_hmac_token(v_s.user_id::text, 'user'),
+    'adapter_kind',        coalesce(v_s.adapter_kind, v_s.detected_kind),
+    'source_kind',         v_s.source_kind,
+    'status',              v_s.status,
+    'source_label_masked', privacy_mask_text(v_label),
+    'rows_total',          v_s.rows_total,
+    'rows_committed',      v_s.rows_committed,
+    'rows_skipped',        v_s.rows_skipped,
+    'rows_duplicate',      v_s.rows_duplicate,
+    'created_at',          v_s.created_at,
+    'committed_at',        v_s.committed_at
+  );
+end $$;
+
+grant execute on function admin_masked_import_session_by_id(uuid) to authenticated;

--- a/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
+++ b/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
@@ -1,0 +1,77 @@
+-- Issue #81: support-safe admin diagnostics via keyed-HMAC pseudonymisation.
+-- Pseudonymisation + masking, NOT anonymisation. Compute-on-read; no stored tokens.
+-- The masked RPCs below are the ONLY deliberate admin cross-user financial path.
+-- Do NOT add is_admin() bypass RLS policies on transactions / import tables.
+
+-- ── 1. HMAC pepper in Vault (idempotent, every env; never committed) ──────────
+do $$
+begin
+  if not exists (select 1 from vault.secrets where name = 'privacy_pepper') then
+    perform vault.create_secret(
+      encode(extensions.gen_random_bytes(32), 'hex'),
+      'privacy_pepper',
+      'HMAC pepper for admin diagnostics pseudonymisation (issue #81)'
+    );
+  end if;
+end $$;
+
+-- ── 2. Internal-only privacy helpers ─────────────────────────────────────────
+create or replace function privacy_hmac_token(p_value text, p_context text)
+returns text
+language plpgsql
+security definer
+set search_path = public, vault, extensions
+as $$
+declare
+  v_pepper text;
+begin
+  if p_value is null or btrim(p_value) = '' then
+    return null;
+  end if;
+  if p_context not in ('user','merchant','group','category','email','import_source') then
+    raise exception 'privacy_hmac_token: disallowed context %', p_context
+      using errcode = '22023';
+  end if;
+  select decrypted_secret into v_pepper
+    from vault.decrypted_secrets
+   where name = 'privacy_pepper'
+   limit 1;
+  if v_pepper is null then
+    raise exception 'privacy_hmac_token: privacy_pepper secret missing (fail closed)'
+      using errcode = 'P0001';
+  end if;
+  return encode(
+    extensions.hmac(p_context || ':' || lower(btrim(p_value)), v_pepper, 'sha256'),
+    'hex'
+  );
+end $$;
+
+create or replace function privacy_amount_bucket(p_amount numeric)
+returns text language sql immutable as $$
+  select case
+    when p_amount is null then null
+    when abs(p_amount) < 50 then '< 50 PLN'
+    when abs(p_amount) < 200 then '50-200 PLN'
+    when abs(p_amount) < 1000 then '200-1000 PLN'
+    else '> 1000 PLN'
+  end
+$$;
+
+create or replace function privacy_mask_email(p_email text)
+returns text language sql immutable as $$
+  select case
+    when p_email is null or btrim(p_email) = '' then null
+    when position('@' in p_email) = 0 then '[masked]'
+    else left(p_email, 1) || '***@' || split_part(p_email, '@', 2)
+  end
+$$;
+
+create or replace function privacy_mask_text(p_label text)
+returns text language sql immutable as $$
+  select case when p_label is null then null else '[masked]' end
+$$;
+
+revoke execute on function privacy_hmac_token(text, text)   from public, anon, authenticated, service_role;
+revoke execute on function privacy_amount_bucket(numeric)   from public, anon, authenticated, service_role;
+revoke execute on function privacy_mask_email(text)         from public, anon, authenticated, service_role;
+revoke execute on function privacy_mask_text(text)          from public, anon, authenticated, service_role;

--- a/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
+++ b/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
@@ -192,3 +192,39 @@ begin
 end $$;
 
 grant execute on function admin_masked_user_context_by_id(uuid) to authenticated;
+
+-- ── 6. Lockdown: mask admin notification diagnostics ──────────────────────────
+drop function if exists fetch_admin_notifications(int);
+
+create or replace function fetch_admin_notifications(p_limit int default 50)
+returns table (
+  id         uuid,
+  user_token text,
+  type       text,
+  title      text,
+  body       text,
+  read_at    timestamptz,
+  created_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public, vault, extensions
+as $$
+begin
+  if not is_admin() then
+    raise exception 'permission_denied: admin only' using errcode = '42501';
+  end if;
+  return query
+    select n.id,
+           privacy_hmac_token(n.user_id::text, 'user'),
+           n.type::text,
+           privacy_mask_text(n.title),
+           privacy_mask_text(n.body),
+           n.read_at,
+           n.created_at
+      from notifications n
+     order by n.created_at desc
+     limit greatest(p_limit, 1);
+end $$;
+
+grant execute on function fetch_admin_notifications(int) to authenticated;

--- a/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
+++ b/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
@@ -228,3 +228,13 @@ begin
 end $$;
 
 grant execute on function fetch_admin_notifications(int) to authenticated;
+
+-- ── 7. Lockdown: admin RPCs are authenticated-only ────────────────────────────
+-- These RPCs are created after 20260529000000_function_execute_hardening.sql, so
+-- the global hardening pass does not cover them. They keep Supabase's default
+-- public/anon EXECUTE grant. The is_admin() guard already blocks data leakage,
+-- but anon/public should not be able to invoke them at all (lockdown convention).
+revoke execute on function admin_masked_transaction_by_id(uuid)    from public, anon;
+revoke execute on function admin_masked_import_session_by_id(uuid) from public, anon;
+revoke execute on function admin_masked_user_context_by_id(uuid)   from public, anon;
+revoke execute on function fetch_admin_notifications(int)          from public, anon;

--- a/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
+++ b/supabase/migrations/20260612000000_admin_diagnostics_privacy.sql
@@ -75,3 +75,47 @@ revoke execute on function privacy_hmac_token(text, text)   from public, anon, a
 revoke execute on function privacy_amount_bucket(numeric)   from public, anon, authenticated, service_role;
 revoke execute on function privacy_mask_email(text)         from public, anon, authenticated, service_role;
 revoke execute on function privacy_mask_text(text)          from public, anon, authenticated, service_role;
+
+-- ── 3. Masked diagnostic RPC: transaction ─────────────────────────────────────
+create or replace function admin_masked_transaction_by_id(p_transaction_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, vault, extensions
+as $$
+declare
+  v_tx          transactions%rowtype;
+  v_merchant    text;
+  v_source_kind text;
+begin
+  if not is_admin() then
+    raise exception 'permission_denied: admin only' using errcode = '42501';
+  end if;
+  select * into v_tx from transactions where id = p_transaction_id;
+  if not found then
+    return null;
+  end if;
+  select r.counterparty, s.source_kind
+    into v_merchant, v_source_kind
+    from transaction_import_links l
+    join transaction_import_rows r     on r.id = l.row_id
+    join transaction_import_sessions s on s.id = l.session_id
+   where l.transaction_id = p_transaction_id;
+  return jsonb_build_object(
+    'transaction_id',     v_tx.id,
+    'user_token',         privacy_hmac_token(v_tx.user_id::text, 'user'),
+    'group_token',        privacy_hmac_token(v_tx.group_id::text, 'group'),
+    'category_token',     privacy_hmac_token(v_tx.category_id::text, 'category'),
+    'type',               v_tx.type,
+    'status',             v_tx.status,
+    'date_month',         to_char(v_tx.date, 'YYYY-MM'),
+    'amount_bucket',      privacy_amount_bucket(v_tx.amount),
+    'currency',           v_tx.currency,
+    'description_masked', privacy_mask_text(v_tx.description),
+    'merchant_token',     privacy_hmac_token(v_merchant, 'merchant'),
+    'source_kind',        v_source_kind,
+    'created_at',         v_tx.created_at
+  );
+end $$;
+
+grant execute on function admin_masked_transaction_by_id(uuid) to authenticated;


### PR DESCRIPTION
<!-- Auto-filled by scripts/open-pr.sh - do not hand-edit. -->
## Summary

- feat(privacy): surface copyable user_token in notif diagnostics; fix runbook path (#81)
- fix(privacy): lock admin diagnostic RPCs to authenticated-only (#81)
- docs(privacy): admin diagnostics masking flow + rotation note (#81)
- feat(privacy): separated admin record-diagnostics panel (#81)
- feat(privacy): typed admin-diagnostics service + regenerated types (#81)
- feat(privacy): mask admin notification diagnostics, return user_token (#81)
- test(privacy): fail-closed pepper + amount-bucket boundaries (#81)
- feat(privacy): masked user-context diagnostics RPC + tests (#81)
- feat(privacy): masked import-session diagnostics RPC + tests (#81)
- feat(privacy): masked transaction diagnostics RPC + tests (#81)
- feat(privacy): pepper bootstrap + internal HMAC/masking helpers (#81)

## Why

- Notification diagnostics received user_token but never rendered it, defeating the
- point of masked correlation - add a copyable monospace token chip. Fix the
- secret-rotation runbook to point at the record-diagnostics panel on /admin (the
- non-existent /admin/diagnostics path was misleading).
- The admin_masked_* RPCs and the masked fetch_admin_notifications were created
- after the global function-execute hardening pass (20260529000000), so they kept
- Supabase's default public/anon EXECUTE grant. The is_admin() guard already blocks
- data leakage, but anon/public should not be able to invoke them at all. Revoke
- execute from public, anon (authenticated retains it) to match the lockdown
- convention.
- Adds a visually distinct amber-bordered diagnostics section to /admin
- that looks up masked transaction / import-session / user records by UUID
- via the typed admin-diagnostics service, rendering only masked fields
- with no raw financial or personal data exposed.
- Replace fetch_admin_notifications with a SECURITY DEFINER override that
- calls privacy_mask_text(title/body) and privacy_hmac_token(user_id,'user'),
- dropping raw user_id and data columns. Page uses a local AdminNotificationRow
- type to match the new shape.
- Fail-closed: transactional psql deletes the privacy_pepper, asserts
- privacy_hmac_token raises "fail closed", then the aborted tx rolls back so the
- secret is restored (verified by a follow-up presence check). Amount-bucket
- boundaries (49.99/50/200/1000) verified through admin_masked_transaction_by_id.
- Appends admin_masked_user_context_by_id to the privacy diagnostics
- migration: admin-only SECURITY DEFINER RPC returning masked email,
- display name, user_token, role, group_count, created_at — no raw
- email or financial fields exposed. Vault pepper ensures stable
- cross-record token correlation. Three new RLS spec cases verify
- non-admin denial, masking correctness, and token stability.
- Add admin_masked_import_session_by_id SECURITY DEFINER RPC that returns
- session counts, adapter/source kind, and HMAC user token while omitting
- source_filename, source_file_hash, and raw account label (privacy_mask_text).
- Two RLS tests: permission_denied for non-admin, no-raw-provenance assertion
- for admin (filename, hash, accountLabel absent; counts + masked label present).
- admin_masked_transaction_by_id: SECURITY DEFINER, is_admin() guard, returns
- only masked/tokenised fields (amount bucketed, description masked, user/group/
- category/merchant HMAC tokens, source_kind). Merchant + source_kind derived via
- transaction_import_links -> rows/sessions; null for manual transactions.
- Tests assert non-admin denial, raw-sentinel non-leakage, masking, and HMAC
- context separation. Seed teardown deletes the full FK-RESTRICT chain (links ->
- rows -> sessions -> bank_accounts) so the suite is idempotent; inserts use
- throwOnError to surface seeding failures.
- Vault pepper (auto-generated if absent, every env) + four internal-only
- helpers: privacy_hmac_token (keyed HMAC, context-separated, fail-closed),
- privacy_amount_bucket, privacy_mask_email, privacy_mask_text. Helpers revoked
- from public, anon, authenticated, service_role (Supabase ALTER DEFAULT
- PRIVILEGES grants execute directly to those roles, so revoke-from-public alone
- is insufficient) - reachable only via SECURITY DEFINER RPCs.

## Gates

- [x] `pnpm exec svelte-check --tsconfig ./tsconfig.json` is 0/0
- [x] `pnpm lint` is clean
- [x] `pnpm format:check` is clean
- [x] `pnpm test:unit` is green
- [x] RLS suite is green
- [x] Secret scan is clean

## Migrations

- [x] New migration names are idempotent and not amended after apply
- [x] RLS is enabled on new tables
- [x] Applied migrations were not modified

## Paraglide

- [x] Recompiled Paraglide (`messages/pl.json` changed)

## Branch Sync

- [x] Branch was synced from `origin/dev` per `CLAUDE.md`