### PR TITLE
docs(privacy): privacy policy, Layer-2 ops-lockdown runbook, beta note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,13 +91,37 @@ the in-app notification row with push as an optional channel.
 
 **Bank import P0 exception-review remediation (issue #66 follow-up, 2026-06-04, branch `fix/import-exception-review-p0`):** the review is now a true exception-review surface. Removed the `queueInitialized` blanket flip in `ImportReviewFlow.svelte` that turned every default-import row into `pending` - it fought the issue #73 default-import model and forced a per-row decision on clean statements. Rows now stay as the deterministic engine decides them (`import`/`duplicate`); a fully auto-categorized statement is one-click committable; uncategorized rows stay `import` and flow to `Inne` via the confirm sheet; `pending` ("Do decyzji") is reserved for rows the user explicitly defers (skip / duplicate-restore). Default selected filter is now `all`, leading with `pending` only when rows await a decision (no empty first screen). E2E mock now faithfully inserts `decision:"import"` (matching `bank-import.ts:302`); +1 bulk-action test; bank-import Playwright 14/14. svelte-check 0/0, lint 0 errors (5 pre-existing Paraglide warnings), format clean, changed-file secret scan clean. P1-3 (editable description on mobile + ungated from counterparty) and P1-6 (decision controls: 44px mobile touch target, desktop text labels, focus-visible ring; `aria-label` retained for icon-only mobile) landed 2026-06-04. P1-5 verified via live EXPLAIN: Path A uses `transaction_import_links_fingerprint_idx (user_id, fingerprint)`, Path C uses the dedicated `idx_transactions_manual_duplicate_scan_user (user_id, type, amount, currency)` anti-join - dedup scans are well-indexed, no schema change; only the minor `OR is_group_member()` arm can't use the composite index (negligible at personal-finance scale - revisit only if a heavy group-shared history shows slow preview/commit). P1-4 row virtualization landed 2026-06-04 (branch `perf/import-review-virtualization`): chunked infinite render in `ImportReviewCategorizeStep.svelte` (CHUNK_SIZE=60, IntersectionObserver sentinel, window resets on filter/sort) - all rows stay mounted (no unmount-on-scroll, so focus/sticky/portal'd combobox can't regress), cheap initial paint at 500 rows; bulk actions/filter counts still run on full `visibleRows`. New Playwright large-import test (500 rows) asserts full count tracked, initial DOM windowed (<200 rows), and scroll reveals the last row (no blank-window/lost-row). bank-import Playwright 15/15, svelte-check 0/0, lint 0 errors, format + secret scan clean. P2 partial landed 2026-06-04 (branch `imp/bank-import-rows-perf` stack): +4 Playwright cases (zero-amount dropped -> skipped banner; resume unsaved draft after reload via `fetchActivePreviewSession`; leave-guard discard on navigate-away; duplicate pre-scan failure now surfaces a non-blocking toast instead of silent swallow - `FileUpload.svelte` + new `bank_upload_duplicate_scan_failed` message). Mock harness extended with an active-preview-session branch + `failMarkDuplicatesOnce`. bank-import Playwright 19/19, svelte-check 0/0, lint 0 errors, format + secret scan clean, paraglide recompiled. P2-8 component/service infra landed 2026-06-04: added `@testing-library/svelte` + `@testing-library/dom` + `jsdom` (devDeps) and a third vitest config `vitest.components.config.ts` (jsdom env, inline svelte preprocess via configFile:false so the SvelteKit `kit` adapter config is not loaded). Service tests live in `tests/services/**` (folded into `vitest.unit.config.ts`, node env, `vi.mock("$lib/supabase")` so the $env import never evaluates) - 13 cases for `bank-import.ts` (insert payload user_id/adapter-kind, excludes-cancelled, active-preview query shape, rows_total, field mapping, soft-cancel, commit RPC + error throw). Component tests in `tests/components/**` - 11 cases for `SingleValueCombobox` (open/filter/select/create/keyboard/Escape) + `ImportCategoryCombobox` (clear chip, select->id, inline create->id). New `test:components` script wired into ci + deploy workflows. NOTE: component tests need real `input.focus()` (not `fireEvent.focus`) because the combobox self-closes when `document.activeElement !== input`, which jsdom's fireEvent.focus does not set. Gates: svelte-check 0/0 (6185 files incl. specs), lint 0 errors, prettier clean, test:unit 47/47 (units+services), test:components 11/11, bank-import Playwright 19/19. `FileUpload.svelte` component test intentionally skipped (heavy decode/detect/multi-service; already e2e-covered). Use corepack pnpm (v11) for installs - the repo's node_modules is linked from the pnpm v11 store.
 
-**Immediate next step:** keep current docs and live work synchronized with the
-product direction above. For schema state, trust `supabase/migrations/` and
-`docs/architecture/database.md`, not historical phase plans.
+**Pre-beta readiness pass (2026-06-05, branch `dev`):** #81 made the privacy
+posture credible; this pass closes the cheap gating items so trusted testers can
+be onboarded before building Plan settlement. (1) Service-role/client exposure
+audit — **clean** (no `service_role` in client `src`, no `PUBLIC_`-prefixed
+secret, example envs placeholder-only, CI keys via `${{ secrets.* }}`, no secret
+echoed to logs); repeatable procedure in the new Layer-2 runbook §3. (2) Layer-2
+ops-lockdown runbook authored: `docs/runbooks/ops-access-lockdown.md` (access
+roster, infra-credential inventory, revocation, access-review schedule) — operator
+must still verify Supabase dashboard members match the roster. (3) Privacy policy:
+`docs/legal/privacy-policy.md` + in-app `/privacy` route (Polish, plain-language;
+not-E2E, who can access, masked admin, deletion now / export partial); linked from
+login page + Settings → Profile; `/privacy` added to `PUBLIC_PATHS`. (4) Beta
+onboarding note: `docs/product/beta-onboarding-note.md` (beta status, upload only
+needed history, not-E2E, deletion, partial export). (5) Full account export
+**documented as a beta limitation**, not built (CSV tx export stays; full export
+planned pre-public). Readiness checklist in
+`docs/architecture/flows/admin-diagnostics-privacy.md` updated. Gates: svelte-check
+0/0, lint 0 errors (5 pre-existing Paraglide warnings), prettier clean (src+docs),
+changed-file secret scan clean (only false positives: documented regex + pre-existing
+`password` var), Paraglide recompiled, Svelte autofixer clean on the new page.
+
+**Immediate next step:** operator-side: verify production Supabase dashboard
+members match the Layer-2 roster, then onboard the first trusted testers using the
+beta note. Product-side: Plan settlement is the MVP+ centerpiece — brainstorm →
+spec → `plan_transaction_links` model + RPCs per
+`docs/architecture/flows/plan-settlement.md` (deterministic-first; do not expand
+`transactions.shopping_list_id`).
 
 **Open backlog:**
 
-- Vault secret rotation runbook (`docs/runbooks/secret-rotation.md`) - Medium, ⏳.
+- Vault secret rotation runbook (`docs/runbooks/secret-rotation.md`) - authored ✅; ops-lockdown runbook (`docs/runbooks/ops-access-lockdown.md`) - authored ✅.
 - Offline write queue (Dexie outbox) - parity gap vs legacy `FirestoreService`, last-write-wins decided - Medium, ⏳.
 - axe-core a11y sweep (deferred U7).
 - Virtualized/infinite scroll for long transaction lists.

--- a/apps/web-svelte/messages/pl.json
+++ b/apps/web-svelte/messages/pl.json
@@ -632,5 +632,7 @@
   "admin_diag_record_id_label": "ID rekordu (UUID)",
   "admin_diag_record_search": "Szukaj",
   "admin_diag_record_not_found": "Nie znaleziono rekordu.",
-  "admin_diag_record_error": "Błąd pobierania diagnostyki."
+  "admin_diag_record_error": "Błąd pobierania diagnostyki.",
+  "privacy_policy_link": "Polityka prywatności",
+  "privacy_beta_notice": "Portfelik jest w wersji beta i nie jest szyfrowany end-to-end. Wgrywaj tylko potrzebną historię."
 }

--- a/apps/web-svelte/src/lib/components/settings/ProfileTab.svelte
+++ b/apps/web-svelte/src/lib/components/settings/ProfileTab.svelte
@@ -323,6 +323,12 @@
       </button>
     </div>
   </div>
+
+  <p class="mt-4 px-1 text-xs text-slate-500">
+    <a href="/privacy" class="text-slate-400 underline hover:text-slate-200"
+      >{m.privacy_policy_link()}</a
+    >
+  </p>
 {/if}
 
 <ConfirmDialog

--- a/apps/web-svelte/src/routes/+layout.svelte
+++ b/apps/web-svelte/src/routes/+layout.svelte
@@ -43,7 +43,7 @@
 
   let { children } = $props();
 
-  const PUBLIC_PATHS = ["/login", "/auth/callback"];
+  const PUBLIC_PATHS = ["/login", "/auth/callback", "/privacy"];
   const PUSH_PROMPT_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
   const PUSH_PROMPT_STORAGE_KEY = "push_prompted_at";
 

--- a/apps/web-svelte/src/routes/login/+page.svelte
+++ b/apps/web-svelte/src/routes/login/+page.svelte
@@ -172,5 +172,12 @@
       </svg>
       {m.login_sign_in_google()}
     </button>
+
+    <p class="mt-6 text-center text-xs leading-relaxed text-slate-500">
+      {m.privacy_beta_notice()}
+      <a href="/privacy" class="text-slate-400 underline hover:text-slate-200"
+        >{m.privacy_policy_link()}</a
+      >
+    </p>
   </div>
 </div>

--- a/apps/web-svelte/src/routes/privacy/+page.svelte
+++ b/apps/web-svelte/src/routes/privacy/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  // Single-language (pl) legal content. Mirrors docs/legal/privacy-policy.md -
+  // keep both in sync. Prose is hardcoded rather than per-paragraph i18n keys
+  // because this is a single-locale legal page and would otherwise bloat pl.json.
+  import * as m from "$lib/paraglide/messages";
+</script>
+
+<svelte:head>
+  <title>{m.privacy_policy_link()} · Portfelik</title>
+</svelte:head>
+
+<main class="mx-auto min-h-screen max-w-2xl px-4 py-10 text-slate-200">
+  <a href="/" class="text-accent text-sm hover:underline">← Portfelik</a>
+
+  <h1 class="mt-4 text-2xl font-semibold tracking-tight text-slate-100">
+    {m.privacy_policy_link()} (beta)
+  </h1>
+  <p class="mt-1 text-xs text-slate-500">Ostatnia aktualizacja: 5 czerwca 2026</p>
+
+  <p class="mt-6 text-sm leading-relaxed text-slate-300">
+    Portfelik jest aplikacją do zarządzania finansami osobistymi, obecnie w wersji
+    <strong>beta</strong>. Poniżej prostym językiem opisujemy, jakie dane przechowujemy, dlaczego,
+    kto technicznie ma do nich dostęp oraz jakie masz prawa.
+  </p>
+
+  <section class="mt-8 space-y-2">
+    <h2 class="text-base font-semibold text-slate-100">Jakie dane przechowujemy</h2>
+    <ul class="list-disc space-y-1 pl-5 text-sm text-slate-300">
+      <li>
+        <strong>Transakcje</strong> — kwota, waluta, data, opis, kontrahent, kategoria, typ oraz oznaczenie
+        czy są prywatne, czy współdzielone w grupie.
+      </li>
+      <li>
+        <strong>Importy z banku</strong> — wgrane pliki CSV są przetwarzane na transakcje; przechowujemy
+        metadane sesji importu potrzebne do wykrywania duplikatów i podsumowań.
+      </li>
+      <li><strong>Plany</strong> — przyszłe zamiary finansowe.</li>
+      <li>
+        <strong>Grupy i zaproszenia</strong> — członkostwo, role oraz adres e-mail osoby zapraszanej (widoczny
+        w ramach współdzielenia z grupą).
+      </li>
+      <li>
+        <strong>Profil</strong> — e-mail logowania, ustawienia (w tym opcjonalne przypomnienia o imporcie),
+        rola konta.
+      </li>
+      <li>
+        <strong>Powiadomienia</strong> — treść powiadomień w aplikacji oraz, jeśli włączysz push, pseudonimowy
+        token subskrypcji danego urządzenia.
+      </li>
+    </ul>
+  </section>
+
+  <section class="mt-8 space-y-2">
+    <h2 class="text-base font-semibold text-slate-100">Dlaczego przechowujemy dane surowe</h2>
+    <p class="text-sm leading-relaxed text-slate-300">
+      Surowe dane finansowe istnieją w produkcyjnej bazie, ponieważ są niezbędne do importów,
+      kategoryzacji, podsumowań, pulpitu i przyszłego rozliczania planów. Aplikacja
+      <strong>nie jest szyfrowana end-to-end</strong> — ochrona polega na kontroli dostępu na poziomie
+      konta i prywatności narzędzi administracyjnych, a nie na kryptograficznym ukryciu danych przed operatorem.
+    </p>
+  </section>
+
+  <section class="mt-8 space-y-2">
+    <h2 class="text-base font-semibold text-slate-100">Kto technicznie ma dostęp</h2>
+    <ul class="list-disc space-y-1 pl-5 text-sm text-slate-300">
+      <li>
+        Dane chroni kontrola dostępu na poziomie konta (RLS). Inni użytkownicy nie widzą Twoich
+        danych poza tymi celowo współdzielonymi w grupie.
+      </li>
+      <li>
+        Jedyny e-mail widoczny dla innego użytkownika to e-mail powiązany ze współdzieleniem w
+        grupie.
+      </li>
+      <li>
+        Narzędzia administracyjne są <strong>maskujące</strong>: kwoty w przedziałach, opisy jako
+        <code>[masked]</code>, e-maile jako <code>a***@domena</code>. Surowe szczegóły finansowe nie
+        są dostępne przez zwykłe ekrany administracyjne.
+      </li>
+      <li>
+        Mimo to operator produkcyjny (właściciel bazy / posiadacz klucza service-role)
+        <strong>technicznie</strong> może odczytać dane surowe. Dostęp produkcyjny jest ograniczony do
+        operatorów, którzy go potrzebują.
+      </li>
+    </ul>
+  </section>
+
+  <section class="mt-8 space-y-2">
+    <h2 class="text-base font-semibold text-slate-100">Powiadomienia push</h2>
+    <p class="text-sm leading-relaxed text-slate-300">
+      Jeśli włączysz powiadomienia push, przechowujemy pseudonimowy token subskrypcji przeglądarki,
+      aby móc dostarczać powiadomienia. Klucz publiczny VAPID jest elementem standardu Web Push i
+      nie identyfikuje Ciebie.
+    </p>
+  </section>
+
+  <section class="mt-8 space-y-2">
+    <h2 class="text-base font-semibold text-slate-100">Usuwanie i eksport danych</h2>
+    <p class="text-sm leading-relaxed text-slate-300">
+      Możesz usunąć konto i dane z poziomu aplikacji (<strong>Ustawienia → Profil</strong>). Eksport
+      danych w tej wersji beta obejmuje transakcje (CSV); pełny eksport konta — obejmujący m.in.
+      kategorie, plany, grupy, reguły i metadane importów — jest zaplanowany przed szerszym
+      publicznym udostępnieniem produktu.
+    </p>
+  </section>
+
+  <section class="mt-8 space-y-2">
+    <h2 class="text-base font-semibold text-slate-100">Status beta</h2>
+    <p class="text-sm leading-relaxed text-slate-300">
+      Portfelik jest w wersji beta. Prosimy, abyś wgrywał(a) tylko tę historię transakcji, której
+      naprawdę potrzebujesz do testów. Zakres przechowywanych danych, eksportu i zabezpieczeń może
+      się zmieniać przed publicznym udostępnieniem.
+    </p>
+  </section>
+</main>

--- a/docs/architecture/flows/admin-diagnostics-privacy.md
+++ b/docs/architecture/flows/admin-diagnostics-privacy.md
@@ -120,9 +120,9 @@ User-facing wording to use (do not overpromise "no one can ever see your data"):
 - [x] RLS suite green (account-level isolation).
 - [x] Admin UI shows no raw financial details (Layer 1, this work).
 - [x] Users can delete their account/data (`delete_account()` RPC + Settings → Profile).
-- [ ] Production Supabase access limited to owner / essential operators (Layer 2, operational).
-- [ ] Service-role keys not exposed anywhere client-side (verify; never ship in client bundle).
-- [ ] Privacy policy states what is stored and who can access it.
-- [ ] Full account-data export (CSV transaction export exists; full export is a gap).
-- [ ] Onboarding asks testers to upload only the history they need.
-- [ ] Beta + "not end-to-end encrypted" communicated to testers.
+- [~] Production Supabase access limited to owner / essential operators (Layer 2). Runbook authored (`docs/runbooks/ops-access-lockdown.md`); operator must verify dashboard members match the roster.
+- [x] Service-role keys not exposed anywhere client-side. Audited 2026-06-05 — clean (no `service_role` in client `src`, no `PUBLIC_`-prefixed secret, example envs placeholder-only, CI passes keys via `${{ secrets.* }}`, no secret echoed to logs). Re-run procedure in the Layer-2 runbook §3.
+- [x] Privacy policy states what is stored and who can access it (`docs/legal/privacy-policy.md` + in-app `/privacy` route).
+- [~] Full account-data export — **documented as a beta limitation**, not built. CSV transaction export exists; full export (categories, plans, groups, rules, import metadata) is planned before wider public release. Stated plainly in privacy policy + beta note.
+- [x] Onboarding asks testers to upload only the history they need (`docs/product/beta-onboarding-note.md`).
+- [x] Beta + "not end-to-end encrypted" communicated to testers (beta note + `/privacy` route + login-page notice).

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,0 +1,75 @@
+# Polityka prywatności (beta)
+
+Ostatnia aktualizacja: 5 czerwca 2026
+
+Portfelik jest aplikacją do zarządzania finansami osobistymi, obecnie w wersji
+**beta**. Ten dokument opisuje prostym językiem, jakie dane przechowujemy,
+dlaczego, kto technicznie ma do nich dostęp oraz jakie masz prawa. Treść tej
+strony jest źródłem dla widoku `/privacy` w aplikacji — zmiany utrzymuj w obu
+miejscach spójnie.
+
+## Jakie dane przechowujemy
+
+- **Transakcje** — kwota, waluta, data, opis, kontrahent/odbiorca, kategoria,
+  typ (przychód/wydatek) oraz oznaczenie czy są prywatne, czy współdzielone w
+  grupie.
+- **Importy z banku** — pliki CSV wgrane przez Ciebie są przetwarzane na
+  transakcje; przechowujemy metadane sesji importu (np. źródło, status, czas
+  zatwierdzenia) potrzebne do wykrywania duplikatów i podsumowań.
+- **Plany** — przyszłe zamiary finansowe (wewnętrznie wciąż oparte o strukturę
+  list zakupowych).
+- **Grupy i zaproszenia** — członkostwo, role oraz adres e-mail osoby
+  zapraszanej/zaproszonej (widoczny w ramach współdzielenia z grupą).
+- **Profil** — adres e-mail logowania, ustawienia (w tym opcjonalne przypomnienia
+  o imporcie), rola konta.
+- **Powiadomienia** — treść powiadomień w aplikacji oraz, jeśli włączysz push w
+  przeglądarce, pseudonimowy token subskrypcji push danego urządzenia.
+
+## Dlaczego przechowujemy dane surowe
+
+Surowe dane finansowe istnieją w produkcyjnej bazie danych, ponieważ są
+niezbędne do działania produktu: importów, kategoryzacji, podsumowań, pulpitu
+oraz przyszłego rozliczania planów względem transakcji. Aplikacja **nie jest
+szyfrowana end-to-end** — ochrona polega na kontroli dostępu na poziomie konta i
+prywatności narzędzi administracyjnych, a nie na kryptograficznym ukryciu danych
+przed operatorem.
+
+## Kto technicznie ma dostęp
+
+- Twoje dane są chronione kontrolą dostępu na poziomie konta (RLS — Row-Level
+  Security). Inni użytkownicy nie widzą Twoich danych, poza danymi celowo
+  współdzielonymi w grupie.
+- Jedyny adres e-mail, który może zobaczyć inny użytkownik, to e-mail powiązany z
+  zaproszeniem/współdzieleniem w grupie.
+- Narzędzia administracyjne/wsparcia są **maskujące**: pokazują dane
+  zdiagnozowane w formie zamaskowanej (kwoty w przedziałach, opisy jako
+  `[masked]`, e-maile jako `a***@domena`). Surowe szczegóły finansowe nie są
+  dostępne przez zwykłe ekrany administracyjne.
+- Mimo to właściciel bazy danych / posiadacz klucza service-role / operator
+  produkcyjny **technicznie** może odczytać dane surowe. Dostęp produkcyjny jest
+  ograniczony do operatorów, którzy go potrzebują (patrz runbook Layer 2).
+
+## Powiadomienia push
+
+Jeśli włączysz powiadomienia push, przechowujemy pseudonimowy token subskrypcji
+przeglądarki, aby móc dostarczać powiadomienia. Klucz publiczny VAPID jest
+elementem standardu Web Push i nie identyfikuje Ciebie.
+
+## Usuwanie i eksport danych
+
+> Możesz usunąć konto i dane z poziomu aplikacji. Eksport danych w tej wersji
+> beta obejmuje transakcje; pełny eksport konta jest w przygotowaniu.
+
+> W beta dostępny jest eksport transakcji do CSV. Pełny eksport konta,
+> obejmujący m.in. kategorie, plany, grupy, reguły i metadane importów, jest
+> zaplanowany przed szerszym publicznym udostępnieniem produktu.
+
+Usunięcie konta realizuje funkcja `delete_account()` dostępna w
+**Ustawienia → Profil** i trwale usuwa Twoje dane.
+
+## Status beta
+
+Portfelik jest w wersji beta. Prosimy, abyś wgrywał(a) tylko tę historię
+transakcji, której naprawdę potrzebujesz do testów. Zakres przechowywanych
+danych, eksportu i zabezpieczeń może się zmieniać przed publicznym
+udostępnieniem.

--- a/docs/product/beta-onboarding-note.md
+++ b/docs/product/beta-onboarding-note.md
@@ -1,0 +1,41 @@
+# Nota onboardingowa dla testerów beta
+
+Ostatnia aktualizacja: 5 czerwca 2026
+
+Krótka, prosta wiadomość do zaufanych testerów. Pełne zasady opisuje
+[polityka prywatności](../legal/privacy-policy.md). Wersja do wysłania (np.
+wiadomość/onboarding) poniżej.
+
+---
+
+**Witaj w becie Portfelika 👋**
+
+Dziękujemy, że pomagasz testować Portfelik. Zanim wgrasz dane, kilka rzeczy
+wprost:
+
+- **To jest wersja beta.** Funkcje i zakres danych mogą się zmieniać.
+- **Wgrywaj tylko potrzebną historię.** Zaimportuj wyłącznie tyle wyciągów
+  bankowych, ile potrzebujesz do testów — nie musisz wrzucać całej historii.
+- **Brak szyfrowania end-to-end.** Twoje dane finansowe są przechowywane w
+  formie surowej, bo są potrzebne do importów, kategoryzacji i podsumowań.
+  Chronimy je kontrolą dostępu na poziomie konta, a narzędzia administracyjne
+  pokazują dane zamaskowane — ale operator produkcyjny technicznie może je
+  odczytać.
+- **Możesz usunąć dane w każdej chwili.** Usunięcie konta i danych jest dostępne
+  w **Ustawienia → Profil**.
+- **Eksport jest częściowy.** W becie wyeksportujesz transakcje do CSV; pełny
+  eksport konta (kategorie, plany, grupy, reguły, metadane importów) jest w
+  przygotowaniu.
+
+Pełne informacje: polityka prywatności w aplikacji (`/privacy`).
+
+Miłego testowania! Każda uwaga się przyda.
+
+---
+
+## Notatki wewnętrzne (nie wysyłać testerom)
+
+- Komunikat ma być pokazany/wysłany **zanim** tester wgra realną historię banku.
+- Spójność: te same fakty (beta, brak E2E, usuwanie teraz, eksport częściowy) są
+  w `docs/legal/privacy-policy.md` i na stronie `/privacy`. Przy zmianie jednego
+  miejsca zaktualizuj pozostałe.

--- a/docs/runbooks/ops-access-lockdown.md
+++ b/docs/runbooks/ops-access-lockdown.md
@@ -1,0 +1,149 @@
+# Operational access lockdown runbook (Layer 2)
+
+Last updated: 2026-06-05
+
+This is **Layer 2** of the three-layer privacy posture described in
+`docs/architecture/flows/admin-diagnostics-privacy.md`:
+
+- **Layer 1 — masked admin diagnostics** (shipped): admin/support tooling never
+  shows raw financial data; HMAC pseudonymisation, bucketed amounts, masked
+  descriptions/emails.
+- **Layer 2 — operational access lockdown** (this doc): who can technically
+  reach the production database/keys, what those keys are, where they live, and
+  how access is revoked. This is process, not code.
+- **Layer 3 — selective column encryption** (future track): cryptographic
+  hiding of specific columns from the operator. Not in scope for beta.
+
+> The app is **not** end-to-end encrypted. Raw data exists in the production DB
+> because imports, categorization, summaries, dashboards, and plan matching need
+> it. A database owner / service-role holder / production operator can
+> technically read it. Layer 2 limits **who** that is and makes access auditable.
+
+---
+
+## 1. Access roster
+
+Production project ref: `emqzcygfwcvbmhxhfkcc`.
+Staging project ref: `portfelik-staging`.
+
+| Principal                  | Scope        | Access level                                  | Justification                          | Review             |
+| -------------------------- | ------------ | --------------------------------------------- | -------------------------------------- | ------------------ |
+| Adrian Zinko (owner)       | prod+staging | Supabase org Owner                            | Sole maintainer/operator               | each review cycle  |
+| GitHub Actions (CI/CD)     | prod+staging | Service-role via secrets, scoped access token | Migrations, seed, Edge Function deploy | on secret rotation |
+| _(add collaborators here)_ | —            | —                                             | —                                      | —                  |
+
+**Principle:** keep production human access to the owner plus only essential
+operators. Every added human must appear in this table with a justification and
+a review date. Prefer giving a collaborator **staging** access first; grant
+production only when a task genuinely requires it.
+
+### Supabase dashboard collaborators
+
+- Audit current members: Supabase Dashboard → Organization → **Team / Members**
+  (per project: Project Settings → Members).
+- Remove anyone not in the roster above. Production should list the owner only
+  unless a collaborator row exists here with justification.
+
+---
+
+## 2. Key & credential inventory
+
+Application/push secrets and their rotation live in
+`docs/runbooks/secret-rotation.md`. This section adds the **operational /
+infrastructure** credentials that grant access rather than power a feature.
+
+| Credential                              | Where it lives                                                                        | Grants                                      | Revoke / rotate                                                               |
+| --------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------- |
+| Supabase **service-role** key (prod)    | GitHub Actions secrets; `apps/web-svelte/.env.cloud.local` (gitignored, opt-in debug) | Full RLS-bypass DB access                   | Dashboard → Project Settings → API → roll keys; update GH secret + local file |
+| Supabase **service-role** key (staging) | GitHub Actions **Staging** secrets only (`STAGING_SUPABASE_SERVICE_ROLE_KEY`)         | Full RLS-bypass DB access on staging        | Staging project → API → roll; update GH Staging secret                        |
+| Supabase **access token** (prod)        | GitHub Actions secrets (CLI auth for migrate/deploy)                                  | CLI/management API as the token owner       | Dashboard → Account → Access Tokens → revoke; reissue                         |
+| Supabase **access token** (staging)     | GitHub Actions Staging secret (`STAGING_SUPABASE_ACCESS_TOKEN`)                       | CLI/management API on staging               | revoke + reissue as above                                                     |
+| DB password (prod / staging)            | GitHub secrets (`*_SUPABASE_DB_PASSWORD`)                                             | Direct Postgres connection                  | Dashboard → Database → reset password; update secret                          |
+| **anon / publishable** key              | `PUBLIC_SUPABASE_ANON_KEY` (build-time, shipped to client — by design)                | RLS-scoped client access only               | rolling invalidates clients; only on compromise                               |
+| MCP connection secrets                  | `.mcp.json` server config (local), per-developer                                      | MCP server access to the configured project | rotate the underlying token it wraps                                          |
+
+**Vault-stored secrets** (`internal_trigger_secret`, `privacy_pepper`,
+`edge_functions_base_url`, `max_user_cap`, VAPID keys) are inventoried and
+rotated in `docs/runbooks/secret-rotation.md`. The `privacy_pepper` is
+security-critical: leaking it defeats Layer-1 admin masking.
+
+---
+
+## 3. Service-role / client-exposure audit (Layer-2 gate)
+
+Run before every beta-tester onboarding wave and after any change touching env
+plumbing, CI, or the Supabase client. Last run: **2026-06-05 — clean**.
+
+```bash
+# A. service_role must never appear in client src (server-only files excepted)
+grep -rniE "service_role|service-role" apps/web-svelte/src \
+  | grep -viE "\.server\.|/server/|hooks\.server"
+
+# B. no JWT literals / secret prefixes committed (allowlisted local-demo keys in .gitleaks.toml are OK).
+#    Excludes: lockfiles (base64 integrity hashes can contain "eyJ"), and the two docs that
+#    quote these patterns verbatim (this runbook + CLAUDE.md) and would self-match.
+git grep -nE "eyJ[a-zA-Z0-9_-]{20,}|sb_secret_|sbp_[a-zA-Z0-9]{20,}" \
+  -- . ':(exclude)*.lock' ':(exclude)pnpm-lock.yaml' \
+  ':(exclude)docs/runbooks/ops-access-lockdown.md' ':(exclude)CLAUDE.md'
+
+# C. SvelteKit only bundles PUBLIC_-prefixed env to the client → no PUBLIC_ secret
+git grep -nE "PUBLIC_[A-Z_]*(SERVICE|SECRET|PRIVATE|ROLE_KEY)" -- . ':(exclude)*.lock'
+
+# D. example env files must be placeholders only
+grep -nE "eyJ[a-zA-Z0-9_-]{20,}|sb_secret_|sbp_[a-zA-Z0-9]{20,}" \
+  .env.local.example apps/web-svelte/.env.example apps/web-svelte/.env.test.example supabase/.env.example
+```
+
+Expected result: A/C/D empty; B only matches the allowlisted local-demo JWTs in
+`.gitleaks.toml`. Anything else is a blocker — stop and remediate before
+onboarding.
+
+> Note: the per-change secret scan in `CLAUDE.md` (step 4) scans changed files
+> directly, so it will flag this runbook (and `CLAUDE.md` itself) on the
+> `sb_secret_` pattern text. Those are documented-example false positives —
+> exclude both files when scanning, same as command B above.
+
+**CI note:** the RLS-suite step writes `SUPABASE_SERVICE_ROLE_KEY` into
+`$GITHUB_ENV` (not stdout), and that value is the **local** `supabase start`
+demo key (publicly known), not a cloud secret. Real cloud keys flow only via
+`${{ secrets.* }}`. No `set -x` or `cat .env` exposes secrets to logs.
+
+---
+
+## 4. Revocation procedures
+
+**Offboard a human collaborator**
+
+1. Supabase Dashboard → remove from Organization/Project members (prod first,
+   then staging).
+2. If they ever held a personal access token or the DB password, rotate those
+   (§2) — membership removal does not invalidate already-issued tokens.
+3. Remove them from the GitHub repo / Actions environment if applicable.
+4. Update the roster table (§1) and note the date.
+
+**Suspected credential compromise** (service-role, access token, DB password,
+or `privacy_pepper`)
+
+1. Treat as a full rotation event — follow `docs/runbooks/secret-rotation.md`
+   for the affected secret, plus §2 here for infra credentials.
+2. Roll the Supabase API keys (invalidates leaked service-role/anon).
+3. Reset the DB password.
+4. Revoke and reissue access tokens.
+5. Update all GitHub secrets and `.env.cloud.local`.
+6. Review recent DB activity for anomalous access.
+
+---
+
+## 5. Access review schedule
+
+- **Cadence:** every release-promotion to production and before each new
+  beta-tester wave.
+- **Checklist:**
+  - [ ] Roster (§1) matches actual Supabase members; no stragglers.
+  - [ ] Production human access = owner + justified operators only.
+  - [ ] §3 audit run and clean.
+  - [ ] No service-role key or DB password in the client bundle, docs, examples,
+        or CI logs.
+  - [ ] Outstanding offboarding completed and tokens rotated.
+- Record the date and result at the top of this file (`Last updated:` + a one
+  line note), the same way `secret-rotation.md` does.


### PR DESCRIPTION
<!-- Auto-filled by scripts/open-pr.sh - do not hand-edit. -->
## Summary

- docs(privacy): privacy policy, Layer-2 ops-lockdown runbook, beta note
- feat(privacy): add in-app /privacy route + entry points

## Why

- See commits above.

## Gates

- [x] `pnpm exec svelte-check --tsconfig ./tsconfig.json` is 0/0
- [x] `pnpm lint` is clean
- [x] `pnpm format:check` is clean
- [x] `pnpm test:unit` is green
- [x] RLS suite - not applicable (no schema/policy change)
- [x] Secret scan is clean

## Migrations

- [x] Not applicable

## Paraglide

- [x] Recompiled Paraglide (`messages/pl.json` changed)

## Branch Sync

- [x] Branch was synced from `origin/dev` per `CLAUDE.md`