### PR TITLE
fix(plans): bucket-aware surplus, queue, and save pace

### DIFF
--- a/apps/web-svelte/e2e/helpers/mock-auth.ts
+++ b/apps/web-svelte/e2e/helpers/mock-auth.ts
@@ -15,18 +15,24 @@ function findMockPlan(url: string) {
   return MOCK_PLANS.find((p) => p.id === match[1]) ?? MOCK_PLANS[0];
 }
 
+/** Debt detail accrues daily interest from terms.updated_at; keep anchor at today in mocks. */
+function withDebtTermsAccrualToday<T extends { updated_at: string }>(terms: T[]): T[] {
+  const anchor = `${new Date().toISOString().slice(0, 10)}T10:00:00Z`;
+  return terms.map((term) => ({ ...term, updated_at: anchor }));
+}
+
 function filterMockDebtTerms(url: string) {
   const inMatch = url.match(/plan_id=in\.\(([^)]+)\)/);
   if (inMatch) {
     const ids = inMatch[1].split(",").map((id) => id.trim());
-    return MOCK_DEBT_TERMS.filter((t) => ids.includes(t.plan_id));
+    return withDebtTermsAccrualToday(MOCK_DEBT_TERMS.filter((t) => ids.includes(t.plan_id)));
   }
   const eqMatch = url.match(/plan_id=eq\.([^&]+)/);
   if (eqMatch) {
     const term = MOCK_DEBT_TERMS.find((t) => t.plan_id === eqMatch[1]);
-    return term ? [term] : [];
+    return term ? withDebtTermsAccrualToday([term]) : [];
   }
-  return MOCK_DEBT_TERMS;
+  return withDebtTermsAccrualToday(MOCK_DEBT_TERMS);
 }
 
 const SUPABASE_URL = "https://emqzcygfwcvbmhxhfkcc.supabase.co";

--- a/apps/web-svelte/messages/pl.json
+++ b/apps/web-svelte/messages/pl.json
@@ -866,6 +866,7 @@
   "plan_save_slider_months": "za {count} mies.",
   "plan_save_link_cta": "Powiąż wpłaty",
   "plan_debt_remaining_hero": "Pozostało do spłaty",
+  "plan_debt_balance_accrued_note": "+{amount} odsetek dziennie od {date} ({days} dni)",
   "plan_debt_stats_rate": "Oprocentowanie",
   "plan_debt_stats_payment": "Rata",
   "plan_debt_stats_daily_interest": "Odsetki",

--- a/apps/web-svelte/src/lib/components/dashboard/DashboardNetWorthStrip.svelte
+++ b/apps/web-svelte/src/lib/components/dashboard/DashboardNetWorthStrip.svelte
@@ -31,16 +31,14 @@
     queryFn: fetchFinancialSnapshot,
   }));
 
-  const netWorthAsOf = $derived(snapshotQuery.data?.as_of_date ?? new Date().toISOString().slice(0, 10));
+  const netWorthAsOf = $derived(
+    snapshotQuery.data?.as_of_date ?? new Date().toISOString().slice(0, 10)
+  );
 
   const netWorth = $derived(
     computeNetWorth(
       snapshotQuery.data ?? null,
-      collectNetWorthDebtBalances(
-        plansQuery.data ?? [],
-        debtTermsQuery.data ?? {},
-        netWorthAsOf
-      )
+      collectNetWorthDebtBalances(plansQuery.data ?? [], debtTermsQuery.data ?? {}, netWorthAsOf)
     )
   );
 

--- a/apps/web-svelte/src/lib/components/dashboard/DashboardNetWorthStrip.svelte
+++ b/apps/web-svelte/src/lib/components/dashboard/DashboardNetWorthStrip.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import * as m from "$lib/paraglide/messages";
-  import { computeNetWorth, fetchFinancialSnapshot } from "$lib/services/financial-snapshots";
+  import {
+    collectNetWorthDebtBalances,
+    computeNetWorth,
+    fetchFinancialSnapshot,
+  } from "$lib/services/financial-snapshots";
   import { fetchPlanDebtTermsByPlanIds } from "$lib/services/plan-debt";
   import { fetchPlans } from "$lib/services/plans";
   import { createQuery } from "@tanstack/svelte-query";
@@ -27,10 +31,16 @@
     queryFn: fetchFinancialSnapshot,
   }));
 
+  const netWorthAsOf = $derived(snapshotQuery.data?.as_of_date ?? new Date().toISOString().slice(0, 10));
+
   const netWorth = $derived(
     computeNetWorth(
       snapshotQuery.data ?? null,
-      Object.values(debtTermsQuery.data ?? {}).map((term) => Number(term.current_balance))
+      collectNetWorthDebtBalances(
+        plansQuery.data ?? [],
+        debtTermsQuery.data ?? {},
+        netWorthAsOf
+      )
     )
   );
 

--- a/apps/web-svelte/src/lib/components/plans/DebtPlanDetail.svelte
+++ b/apps/web-svelte/src/lib/components/plans/DebtPlanDetail.svelte
@@ -3,13 +3,16 @@
   import { page } from "$app/stores";
   import {
     approximateDailyInterest,
+    accrueBalanceWithDailyInterest,
     compareLumpSumOverpay,
     compareOverpay,
+    daysBetween,
     formatDuration,
     isPaymentBelowMonthlyInterest,
     monthlyInterestAmount,
   } from "$lib/services/debt-amortization";
   import { normalizeDebtTermsInput, type PlanDebtTermsInput } from "$lib/services/plan-debt";
+  import { todayIso } from "$lib/services/plans";
   import type { PlanDebtTerms } from "$lib/types";
   import { cn, formatCurrency } from "$lib/utils";
   import {
@@ -21,6 +24,7 @@
   import { planSettleHref } from "$lib/utils/plan-routes";
   import PlanForwardNav from "$lib/components/plans/PlanForwardNav.svelte";
   import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
+  import DayPicker from "$lib/components/ui/DayPicker.svelte";
   import { ChevronRight } from "lucide-svelte";
   import { onMount } from "svelte";
   import { toast } from "svelte-sonner";
@@ -29,10 +33,13 @@
   interface Props {
     planId: string;
     terms: PlanDebtTerms;
+    planStartDate: string;
+    planEndDate: string;
     derivedBalance?: number | null;
     linkedExpenseTotal?: number;
     onSyncBalance?: () => void | Promise<void>;
     onTermsSave?: (input: PlanDebtTermsInput) => void | Promise<void>;
+    onPlanDatesSave?: (dates: { start_date: string; end_date: string }) => void | Promise<void>;
     syncing?: boolean;
     termsSaving?: boolean;
   }
@@ -40,10 +47,13 @@
   let {
     planId,
     terms,
+    planStartDate,
+    planEndDate,
     derivedBalance = null,
     linkedExpenseTotal = 0,
     onSyncBalance,
     onTermsSave,
+    onPlanDatesSave,
     syncing = false,
     termsSaving = false,
   }: Props = $props();
@@ -54,43 +64,62 @@
   let editBalance = $state("");
   let editRate = $state("");
   let editPayment = $state("");
+  let editStartDate = $state("");
+  let editEndDate = $state("");
 
   $effect(() => {
     editOriginal = String(terms.original_amount);
     editBalance = String(terms.current_balance);
     editRate = String(terms.annual_rate);
     editPayment = String(terms.monthly_payment);
+    editStartDate = planStartDate;
+    editEndDate = planEndDate;
   });
 
-  const paid = $derived(Math.max(0, terms.original_amount - terms.current_balance));
+  const hasLinkedPayments = $derived(linkedExpenseTotal > 0.01);
+  const accrualAnchor = $derived(terms.updated_at.slice(0, 10));
+  const accrualDays = $derived(daysBetween(accrualAnchor, todayIso()));
+  const storedBalance = $derived(Number(terms.current_balance));
+  const displayBalance = $derived(
+    hasLinkedPayments
+      ? storedBalance
+      : accrueBalanceWithDailyInterest(
+          storedBalance,
+          Number(terms.annual_rate),
+          accrualAnchor,
+          todayIso()
+        )
+  );
+  const accruedInterestAmount = $derived(Math.max(0, displayBalance - storedBalance));
+  const paid = $derived(Math.max(0, Number(terms.original_amount) - displayBalance));
   const paidPct = $derived(
     terms.original_amount > 0 ? Math.round((paid / terms.original_amount) * 100) : 0
   );
   const dailyInterest = $derived(
-    approximateDailyInterest(Number(terms.current_balance), Number(terms.annual_rate))
+    approximateDailyInterest(displayBalance, Number(terms.annual_rate))
   );
   const monthlyInterest = $derived(
-    monthlyInterestAmount(Number(terms.current_balance), Number(terms.annual_rate))
+    monthlyInterestAmount(displayBalance, Number(terms.annual_rate))
   );
   const paymentBelowInterest = $derived(
     isPaymentBelowMonthlyInterest(
-      Number(terms.current_balance),
+      displayBalance,
       Number(terms.annual_rate),
       Number(terms.monthly_payment)
     )
   );
   const amortInput = $derived({
-    currentBalance: Number(terms.current_balance),
+    currentBalance: displayBalance,
     annualRate: Number(terms.annual_rate),
     monthlyPayment: Number(terms.monthly_payment),
   });
   const maxOverpay = $derived(
     Math.min(
-      Math.max(0, Number(terms.current_balance)),
+      Math.max(0, displayBalance),
       Math.max(10_000, Math.ceil(Number(terms.monthly_payment) * 5))
     )
   );
-  const maxLumpSum = $derived(Math.max(0, Math.floor(Number(terms.current_balance))));
+  const maxLumpSum = $derived(Math.max(0, Math.floor(displayBalance)));
   const simState = $derived(parseDebtSimUrl($page.url.searchParams));
   const overpayMode = $derived(simState.mode);
   const extraPayment = $derived(Math.min(maxOverpay, simState.extra));
@@ -102,7 +131,6 @@
       ? Math.round((comparison.withExtra.payoffMonths / comparison.baseline.payoffMonths) * 100)
       : 100
   );
-  const hasLinkedPayments = $derived(linkedExpenseTotal > 0.01);
   const balanceDrift = $derived(
     hasLinkedPayments &&
       derivedBalance != null &&
@@ -190,6 +218,10 @@
   }
 
   async function saveTermsEdit() {
+    if (editEndDate < editStartDate) {
+      toast.error(m.plan_form_dates_invalid());
+      return;
+    }
     try {
       const input = normalizeDebtTermsInput({
         original_amount: Number(editOriginal),
@@ -200,6 +232,12 @@
         anchor_transaction_id: terms.anchor_transaction_id,
       });
       await onTermsSave?.(input);
+      if (
+        onPlanDatesSave &&
+        (editStartDate !== planStartDate || editEndDate !== planEndDate)
+      ) {
+        await onPlanDatesSave({ start_date: editStartDate, end_date: editEndDate });
+      }
       showTermsEdit = false;
     } catch (err) {
       const code = err instanceof Error ? err.message : "";
@@ -262,8 +300,17 @@
   >
     <p class="text-eyebrow text-slate-400">{m.plan_debt_remaining_hero()}</p>
     <p class="text-accent mt-2 text-4xl font-semibold tabular-nums">
-      {formatCurrency(Number(terms.current_balance))}
+      {formatCurrency(displayBalance)}
     </p>
+    {#if accruedInterestAmount > 0.01 && !hasLinkedPayments}
+      <p class="mt-1 text-xs text-amber-200/90">
+        {m.plan_debt_balance_accrued_note({
+          date: accrualAnchor,
+          amount: formatCurrency(accruedInterestAmount),
+          days: accrualDays,
+        })}
+      </p>
+    {/if}
     <p class="mt-1 text-sm text-slate-400">
       z {formatCurrency(Number(terms.original_amount))}
     </p>
@@ -557,6 +604,24 @@
               class="mt-1 w-full rounded-lg border border-white/10 bg-slate-900/60 px-3 py-2 text-sm text-slate-100"
             />
           </label>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <DayPicker
+              id="debt-edit-start-{planId}"
+              bind:value={editStartDate}
+              label={m.plan_form_start_date()}
+              yearsPast={50}
+              yearsAhead={1}
+              showLabel={true}
+            />
+            <DayPicker
+              id="debt-edit-end-{planId}"
+              bind:value={editEndDate}
+              label={m.plan_form_end_date_debt()}
+              yearsPast={0}
+              yearsAhead={100}
+              showLabel={true}
+            />
+          </div>
           <button
             type="button"
             disabled={termsSaving}

--- a/apps/web-svelte/src/lib/components/plans/DebtPlanDetail.svelte
+++ b/apps/web-svelte/src/lib/components/plans/DebtPlanDetail.svelte
@@ -232,10 +232,7 @@
         anchor_transaction_id: terms.anchor_transaction_id,
       });
       await onTermsSave?.(input);
-      if (
-        onPlanDatesSave &&
-        (editStartDate !== planStartDate || editEndDate !== planEndDate)
-      ) {
+      if (onPlanDatesSave && (editStartDate !== planStartDate || editEndDate !== planEndDate)) {
         await onPlanDatesSave({ start_date: editStartDate, end_date: editEndDate });
       }
       showTermsEdit = false;

--- a/apps/web-svelte/src/lib/components/plans/PlanCard.svelte
+++ b/apps/web-svelte/src/lib/components/plans/PlanCard.svelte
@@ -50,7 +50,9 @@
   );
   const saveOnTrack = $derived(
     kind === "save" &&
+      plan.bucket === "active" &&
       plan.monthlyNeeded != null &&
+      plan.monthlyNeeded > 0 &&
       plan.monthlyActual != null &&
       plan.monthlyActual >= plan.monthlyNeeded - 0.01
   );

--- a/apps/web-svelte/src/lib/components/ui/DayPicker.svelte
+++ b/apps/web-svelte/src/lib/components/ui/DayPicker.svelte
@@ -62,6 +62,16 @@
     return Array.from({ length: to - from + 1 }, (_, i) => from + i);
   });
 
+  const yearMin = $derived(yearOptions[0] ?? today(tz).year);
+  const yearMax = $derived(yearOptions[yearOptions.length - 1] ?? today(tz).year);
+
+  function setCalendarYear(raw: string) {
+    const y = parseInt(raw, 10);
+    if (!Number.isFinite(y)) return;
+    const clamped = Math.min(yearMax, Math.max(yearMin, y));
+    calendarPlaceholder = calendarPlaceholder.set({ year: clamped });
+  }
+
   function toValue(iso: string | null | undefined): DateValue | undefined {
     if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return undefined;
     try {
@@ -197,11 +207,16 @@
             monthFormat="long"
             aria-label={m.day_picker_select_month()}
           />
-          <Calendar.YearSelect
-            class={selectClass}
-            years={yearOptions}
-            yearFormat="numeric"
+          <input
+            type="number"
+            class={cn(selectClass, "w-[4.75rem] shrink-0 tabular-nums")}
+            min={yearMin}
+            max={yearMax}
+            step="1"
+            inputmode="numeric"
             aria-label={m.day_picker_select_year()}
+            value={calendarPlaceholder.year}
+            oninput={(e) => setCalendarYear(e.currentTarget.value)}
           />
         </div>
         <Calendar.NextButton

--- a/apps/web-svelte/src/lib/services/debt-amortization.ts
+++ b/apps/web-svelte/src/lib/services/debt-amortization.ts
@@ -183,6 +183,29 @@ export function approximateDailyInterest(currentBalance: number, annualRate: num
   return (currentBalance * (annualRate / 100)) / 365;
 }
 
+/** Whole calendar days from `fromIso` (exclusive anchor) to `toIso` (inclusive end). */
+export function daysBetween(fromIso: string, toIso: string): number {
+  const [fy, fm, fd] = fromIso.split("-").map(Number);
+  const [ty, tm, td] = toIso.split("-").map(Number);
+  const from = Date.UTC(fy, fm - 1, fd);
+  const to = Date.UTC(ty, tm - 1, td);
+  return Math.floor((to - from) / 86_400_000);
+}
+
+/** Compound daily interest on outstanding balance since the anchor date. */
+export function accrueBalanceWithDailyInterest(
+  balance: number,
+  annualRatePct: number,
+  anchorDateIso: string,
+  asOfDateIso: string
+): number {
+  if (balance <= 0.01 || annualRatePct <= 0) return balance;
+  const days = daysBetween(anchorDateIso, asOfDateIso);
+  if (days <= 0) return balance;
+  const dailyRate = annualRatePct / 100 / 365;
+  return balance * Math.pow(1 + dailyRate, days);
+}
+
 /** Monthly interest on the current balance at the plan rate. */
 export function monthlyInterestAmount(currentBalance: number, annualRate: number): number {
   return currentBalance * (annualRate / 100 / 12);

--- a/apps/web-svelte/src/lib/services/financial-snapshots.ts
+++ b/apps/web-svelte/src/lib/services/financial-snapshots.ts
@@ -1,5 +1,7 @@
+import { accrueBalanceWithDailyInterest } from "$lib/services/debt-amortization";
+import { derivePlanBucket, todayIso } from "$lib/services/plans";
+import type { FinancialSnapshot, NetWorthSummary, Plan, PlanDebtTerms } from "$lib/types";
 import { supabase } from "$lib/supabase";
-import type { FinancialSnapshot, NetWorthSummary } from "$lib/types";
 
 export interface FinancialSnapshotInput {
   as_of_date: string;
@@ -28,6 +30,50 @@ export function computeNetWorth(
     totalDebt,
     netWorth: totalAssets - totalDebt,
   };
+}
+
+/** Balance for one debt plan in net-worth (active + upcoming; finished only if balance remains). */
+export function debtBalanceForNetWorth(
+  plan: Pick<Plan, "start_date" | "end_date" | "target_amount">,
+  terms: PlanDebtTerms | undefined,
+  asOfDate = todayIso()
+): number {
+  const bucket = derivePlanBucket(plan, asOfDate);
+
+  if (bucket === "finished") {
+    if (!terms) return 0;
+    const remaining = Number(terms.current_balance);
+    return remaining > 0.01 ? remaining : 0;
+  }
+
+  if (terms) {
+    if (bucket === "upcoming") {
+      // Future loan: full principal obligation counts toward net worth today.
+      return Math.max(Number(terms.current_balance), Number(terms.original_amount));
+    }
+    const anchor = terms.updated_at.slice(0, 10);
+    return accrueBalanceWithDailyInterest(
+      Number(terms.current_balance),
+      Number(terms.annual_rate),
+      anchor,
+      asOfDate
+    );
+  }
+
+  // Plan exists but terms not saved yet — use target_amount from create form.
+  const fallback = plan.target_amount != null ? Number(plan.target_amount) : 0;
+  return fallback > 0.01 ? fallback : 0;
+}
+
+export function collectNetWorthDebtBalances(
+  plans: Plan[],
+  termsByPlanId: Record<string, PlanDebtTerms>,
+  asOfDate = todayIso()
+): number[] {
+  return plans
+    .filter((plan) => plan.kind === "debt")
+    .map((plan) => debtBalanceForNetWorth(plan, termsByPlanId[plan.id], asOfDate))
+    .filter((balance) => balance > 0.01);
 }
 
 export async function fetchFinancialSnapshot(): Promise<FinancialSnapshot | null> {

--- a/apps/web-svelte/src/lib/services/financial-surplus.ts
+++ b/apps/web-svelte/src/lib/services/financial-surplus.ts
@@ -1,4 +1,8 @@
-import type { PlanDebtTerms, PlanKind } from "$lib/types";
+import type { Plan, PlanDebtTerms, PlanKind } from "$lib/types";
+
+function isActivePlan(plan: { start_date: string; end_date: string }, today: string): boolean {
+  return plan.start_date <= today && plan.end_date >= today;
+}
 
 export interface MonthlySurplusInput {
   totalIncome: number;
@@ -34,8 +38,17 @@ export function computeMonthlySurplus(input: MonthlySurplusInput): MonthlySurplu
   };
 }
 
-export function sumDebtMonthlyPayments(terms: Record<string, PlanDebtTerms>): number {
-  return Object.values(terms).reduce((sum, term) => sum + Number(term.monthly_payment), 0);
+export function sumDebtMonthlyPayments(
+  plans: Pick<Plan, "id" | "kind" | "start_date" | "end_date">[],
+  termsByPlanId: Record<string, PlanDebtTerms>,
+  today = new Date().toISOString().slice(0, 10)
+): number {
+  return plans
+    .filter((plan) => plan.kind === "debt" && isActivePlan(plan, today))
+    .reduce((sum, plan) => {
+      const terms = termsByPlanId[plan.id];
+      return sum + (terms ? Number(terms.monthly_payment) : 0);
+    }, 0);
 }
 
 export function sumSaveMonthlyNeeded(
@@ -51,8 +64,7 @@ export function sumSaveMonthlyNeeded(
     .filter(
       (plan) =>
         (plan.kind ?? "spend") === "save" &&
-        (plan.start_date ?? today) <= today &&
-        plan.end_date >= today
+        isActivePlan({ start_date: plan.start_date ?? today, end_date: plan.end_date }, today)
     )
     .reduce((sum, plan) => sum + (plan.monthlyNeeded ?? 0), 0);
 }

--- a/apps/web-svelte/src/lib/services/plan-settlement.ts
+++ b/apps/web-svelte/src/lib/services/plan-settlement.ts
@@ -6,6 +6,7 @@ import {
   SETTLEMENT_STATUSES,
 } from "$lib/services/plan-settlement-policy";
 import {
+  derivePlanBucket,
   monthsBetween,
   monthsRemaining as planMonthsRemaining,
   todayIso,
@@ -268,12 +269,20 @@ function sumLinkedIncomeInMonth(
 export function computeSaveMonthlyActual(input: {
   kind?: import("$lib/types").PlanKind;
   startDate?: string;
+  endDate?: string;
   savedAmount: number;
   linkedIncomes: TransactionWithCategory[];
   today?: string;
 }): number | null {
   if (input.kind !== "save") return null;
   const today = input.today ?? todayIso();
+  if (
+    input.startDate &&
+    input.endDate &&
+    derivePlanBucket({ start_date: input.startDate, end_date: input.endDate }, today) !== "active"
+  ) {
+    return 0;
+  }
   const bounds = currentCalendarMonthBounds(new Date(today));
   const currentMonthDeposits = sumLinkedIncomeInMonth(
     input.linkedIncomes,
@@ -298,6 +307,7 @@ export function computePlanProgress(input: {
   eligibleCount?: number;
   today?: string;
 }): PlanSettlementProgress {
+  const today = input.today ?? todayIso();
   const paidLinked = input.linkedTransactions.filter((t) => isSettlementStatus(t.status));
   const expenses = paidLinked.filter((t) => t.type === "expense");
   const incomes = paidLinked.filter((t) => t.type === "income");
@@ -312,16 +322,22 @@ export function computePlanProgress(input: {
         ? Math.max(0, targetAmount - savedAmount)
         : null;
   const monthsRem = input.endDate ? planMonthsRemaining(input.endDate) : null;
+  const isActive =
+    input.startDate && input.endDate
+      ? derivePlanBucket({ start_date: input.startDate, end_date: input.endDate }, today) ===
+        "active"
+      : true;
   const monthlyNeeded =
-    targetAmount != null && targetAmount > 0 && monthsRem != null && monthsRem > 0
+    isActive && targetAmount != null && targetAmount > 0 && monthsRem != null && monthsRem > 0
       ? Math.max(0, (targetAmount - savedAmount) / monthsRem)
       : null;
   const monthlyActual = computeSaveMonthlyActual({
     kind: input.kind,
     startDate: input.startDate,
+    endDate: input.endDate,
     savedAmount,
     linkedIncomes: incomes,
-    today: input.today,
+    today,
   });
   return {
     planId: input.planId,

--- a/apps/web-svelte/src/lib/services/planning-queue.ts
+++ b/apps/web-svelte/src/lib/services/planning-queue.ts
@@ -29,7 +29,7 @@ export function buildPlanningQueueActions(input: {
   }
 
   const settleCandidates = summaries
-    .filter((p) => p.kind === "spend" && (p.eligibleCount ?? 0) > 0)
+    .filter((p) => p.kind === "spend" && p.bucket === "active" && (p.eligibleCount ?? 0) > 0)
     .sort((a, b) => (b.eligibleCount ?? 0) - (a.eligibleCount ?? 0));
   const totalEligible = settleCandidates.reduce((sum, p) => sum + (p.eligibleCount ?? 0), 0);
   if (totalEligible > 0 && settleCandidates[0]) {
@@ -53,6 +53,7 @@ export function buildPlanningQueueActions(input: {
     .filter(
       (p) =>
         p.kind === "save" &&
+        p.bucket === "active" &&
         p.monthlyNeeded != null &&
         p.monthlyNeeded > 0 &&
         (p.monthlyActual ?? 0) < p.monthlyNeeded - 0.01
@@ -71,14 +72,14 @@ export function buildPlanningQueueActions(input: {
     });
   }
 
-  const debtPlans = summaries.filter((p) => p.kind === "debt");
-  if (debtPlans.length > 0) {
-    const totalDebtPayment = debtPlans.reduce((sum, p) => {
+  const activeDebtPlans = summaries.filter((p) => p.kind === "debt" && p.bucket === "active");
+  if (activeDebtPlans.length > 0) {
+    const totalDebtPayment = activeDebtPlans.reduce((sum, p) => {
       const terms = debtTerms[p.id];
       return sum + (terms ? Number(terms.monthly_payment) : 0);
     }, 0);
     if (totalDebtPayment > 0) {
-      const first = debtPlans[0];
+      const first = activeDebtPlans[0];
       actions.push({
         id: `debt-${first.id}`,
         href: `/plans/${first.id}`,

--- a/apps/web-svelte/src/routes/plans/+page.svelte
+++ b/apps/web-svelte/src/routes/plans/+page.svelte
@@ -19,6 +19,7 @@
     normalizeDebtTermsInput,
   } from "$lib/services/plan-debt";
   import {
+    collectNetWorthDebtBalances,
     computeNetWorth,
     fetchFinancialSnapshot,
     upsertFinancialSnapshot,
@@ -146,8 +147,10 @@
     queryFn: fetchFinancialSnapshot,
   }));
 
+  const netWorthAsOf = $derived(snapshotQuery.data?.as_of_date ?? todayIsoLocal());
+
   const debtBalances = $derived(
-    Object.values(debtTermsQuery.data ?? {}).map((t) => Number(t.current_balance))
+    collectNetWorthDebtBalances(plansQuery.data ?? [], debtTermsQuery.data ?? {}, netWorthAsOf)
   );
 
   const netWorth = $derived(computeNetWorth(snapshotQuery.data ?? null, debtBalances));

--- a/apps/web-svelte/src/routes/plans/+page.svelte
+++ b/apps/web-svelte/src/routes/plans/+page.svelte
@@ -215,7 +215,7 @@
     return computeMonthlySurplus({
       totalIncome: monthSummary.total_income,
       totalExpenses: monthSummary.total_expenses,
-      debtMonthlyPayments: sumDebtMonthlyPayments(scopedDebtTerms),
+      debtMonthlyPayments: sumDebtMonthlyPayments(scopedSummaries, scopedDebtTerms),
       saveMonthlyNeeded: sumSaveMonthlyNeeded(scopedSummaries),
     });
   });
@@ -223,9 +223,9 @@
   const planningActions = $derived.by(() => {
     if (!monthlySurplus) return [];
     return buildPlanningQueueActions({
-      summaries,
+      summaries: scopedSummaries,
       monthlySurplus,
-      debtTerms: debtTermsQuery.data ?? {},
+      debtTerms: scopedDebtTerms,
     });
   });
 

--- a/apps/web-svelte/src/routes/plans/+page.svelte
+++ b/apps/web-svelte/src/routes/plans/+page.svelte
@@ -733,12 +733,20 @@
     </div>
 
     <div class="grid gap-3 sm:grid-cols-2">
-      <DayPicker id="plan-start" bind:value={startDate} label={m.plan_form_start_date()} required />
+      <DayPicker
+        id="plan-start"
+        bind:value={startDate}
+        label={m.plan_form_start_date()}
+        yearsPast={planKind === "debt" ? 50 : 100}
+        yearsAhead={planKind === "debt" ? 1 : 15}
+        required
+      />
       <DayPicker
         id="plan-end"
         bind:value={endDate}
         label={planKind === "debt" ? m.plan_form_end_date_debt() : m.plan_form_end_date()}
-        yearsAhead={planKind === "debt" ? 5 : 15}
+        yearsPast={planKind === "debt" ? 0 : 100}
+        yearsAhead={planKind === "debt" ? 100 : 15}
         required
       />
     </div>

--- a/apps/web-svelte/src/routes/plans/[id]/+page.svelte
+++ b/apps/web-svelte/src/routes/plans/[id]/+page.svelte
@@ -416,9 +416,7 @@
         {linkedExpenseTotal}
         onSyncBalance={canManage ? () => syncBalanceMutation.mutate() : undefined}
         onTermsSave={canManage ? (input) => debtTermsMutation.mutate(input) : undefined}
-        onPlanDatesSave={canManage
-          ? (dates) => debtPlanDatesMutation.mutate(dates)
-          : undefined}
+        onPlanDatesSave={canManage ? (dates) => debtPlanDatesMutation.mutate(dates) : undefined}
         syncing={syncBalanceMutation.isPending}
         termsSaving={debtTermsMutation.isPending || debtPlanDatesMutation.isPending}
       />

--- a/apps/web-svelte/src/routes/plans/[id]/+page.svelte
+++ b/apps/web-svelte/src/routes/plans/[id]/+page.svelte
@@ -264,6 +264,27 @@
     onError: () => toast.error(m.toast_error()),
   }));
 
+  const debtPlanDatesMutation = createMutation(() => ({
+    mutationFn: (dates: { start_date: string; end_date: string }) => {
+      const plan = planQuery.data!;
+      return updatePlan(id, {
+        name: plan.name,
+        kind: "debt",
+        start_date: dates.start_date,
+        end_date: dates.end_date,
+        target_amount: plan.target_amount,
+        category_id: plan.category_id,
+        group_id: plan.group_id,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["plan", id] });
+      await queryClient.invalidateQueries({ queryKey: ["plans"] });
+      await queryClient.invalidateQueries({ queryKey: ["plan-progress-list"] });
+    },
+    onError: () => toast.error(m.toast_error()),
+  }));
+
   const syncBalanceMutation = createMutation(() => ({
     mutationFn: async () => {
       if (derivedDebtBalance == null) return;
@@ -389,12 +410,17 @@
       <DebtPlanDetail
         planId={id}
         terms={debtTermsQuery.data}
+        planStartDate={plan.start_date}
+        planEndDate={plan.end_date}
         derivedBalance={derivedDebtBalance}
         {linkedExpenseTotal}
         onSyncBalance={canManage ? () => syncBalanceMutation.mutate() : undefined}
         onTermsSave={canManage ? (input) => debtTermsMutation.mutate(input) : undefined}
+        onPlanDatesSave={canManage
+          ? (dates) => debtPlanDatesMutation.mutate(dates)
+          : undefined}
         syncing={syncBalanceMutation.isPending}
-        termsSaving={debtTermsMutation.isPending}
+        termsSaving={debtTermsMutation.isPending || debtPlanDatesMutation.isPending}
       />
       <PlanForwardNav href={settleHref} title={m.plan_debt_link_payments()} variant="action" />
     {:else if progress}

--- a/apps/web-svelte/tests/unit/debt-amortization.spec.ts
+++ b/apps/web-svelte/tests/unit/debt-amortization.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  accrueBalanceWithDailyInterest,
   approximateDailyInterest,
   compareLumpSumOverpay,
   compareLumpSumVsInvest,
   compareOverpay,
   compareOverpayVsInvest,
+  daysBetween,
   isPaymentBelowMonthlyInterest,
   monthlyInterestAmount,
   simulateAmortization,
@@ -119,5 +121,17 @@ describe("simulateAmortization", () => {
         MORTGAGE.monthlyPayment
       )
     ).toBe(false);
+  });
+
+  it("counts whole days between ISO dates", () => {
+    expect(daysBetween("2026-06-01", "2026-06-01")).toBe(0);
+    expect(daysBetween("2026-06-01", "2026-06-08")).toBe(7);
+  });
+
+  it("accrues daily compound interest from anchor date", () => {
+    const base = 200_000;
+    const afterWeek = accrueBalanceWithDailyInterest(base, 7.18, "2026-06-01", "2026-06-08");
+    expect(afterWeek).toBeGreaterThan(base);
+    expect(afterWeek).toBeLessThan(base + approximateDailyInterest(base, 7.18) * 8);
   });
 });

--- a/apps/web-svelte/tests/unit/financial-snapshots.spec.ts
+++ b/apps/web-svelte/tests/unit/financial-snapshots.spec.ts
@@ -2,8 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("$lib/supabase", () => ({ supabase: {} }));
 
-import { computeNetWorth } from "$lib/services/financial-snapshots";
-import type { FinancialSnapshot } from "$lib/types";
+import {
+  collectNetWorthDebtBalances,
+  computeNetWorth,
+  debtBalanceForNetWorth,
+} from "$lib/services/financial-snapshots";
+import type { FinancialSnapshot, Plan, PlanDebtTerms } from "$lib/types";
 
 const snapshot: FinancialSnapshot = {
   user_id: "u1",
@@ -29,5 +33,89 @@ describe("computeNetWorth", () => {
     expect(result.hasSnapshot).toBe(false);
     expect(result.totalAssets).toBe(0);
     expect(result.netWorth).toBe(-100_000);
+  });
+});
+
+const debtPlan = (overrides: Partial<Plan> = {}): Plan => ({
+  id: "debt-1",
+  name: "Hipoteka",
+  user_id: "u1",
+  group_id: null,
+  category_id: null,
+  kind: "debt",
+  budget_amount: null,
+  target_amount: 200_000,
+  start_date: "2026-07-01",
+  end_date: "2046-07-01",
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  ...overrides,
+});
+
+const debtTerms = (overrides: Partial<PlanDebtTerms> = {}): PlanDebtTerms => ({
+  plan_id: "debt-1",
+  original_amount: 200_000,
+  current_balance: 200_000,
+  annual_rate: 7,
+  monthly_payment: 1400,
+  payment_day: null,
+  anchor_transaction_id: null,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  ...overrides,
+});
+
+describe("debtBalanceForNetWorth", () => {
+  it("counts full original for upcoming loans", () => {
+    const balance = debtBalanceForNetWorth(
+      debtPlan({ start_date: "2026-07-01" }),
+      debtTerms({ original_amount: 200_000, current_balance: 199_000 }),
+      "2026-06-08"
+    );
+    expect(balance).toBe(200_000);
+  });
+
+  it("falls back to plan target when terms row is missing", () => {
+    const balance = debtBalanceForNetWorth(
+      debtPlan({ target_amount: 150_000, start_date: "2026-08-01" }),
+      undefined,
+      "2026-06-08"
+    );
+    expect(balance).toBe(150_000);
+  });
+
+  it("excludes finished loans with zero balance", () => {
+    const balance = debtBalanceForNetWorth(
+      debtPlan({ start_date: "2020-01-01", end_date: "2025-12-31" }),
+      debtTerms({ current_balance: 0 }),
+      "2026-06-08"
+    );
+    expect(balance).toBe(0);
+  });
+});
+
+describe("collectNetWorthDebtBalances", () => {
+  it("sums active and upcoming debt plans", () => {
+    const plans = [
+      debtPlan({ id: "d1", start_date: "2025-01-01", end_date: "2030-01-01" }),
+      debtPlan({
+        id: "d2",
+        start_date: "2026-09-01",
+        end_date: "2046-09-01",
+        target_amount: 100_000,
+      }),
+    ];
+    const terms = {
+      d1: debtTerms({
+        plan_id: "d1",
+        original_amount: 207_000,
+        current_balance: 207_000,
+        updated_at: "2026-06-08T00:00:00Z",
+      }),
+      d2: debtTerms({ plan_id: "d2", original_amount: 100_000, current_balance: 100_000 }),
+    };
+    const balances = collectNetWorthDebtBalances(plans, terms, "2026-06-08");
+    expect(balances).toHaveLength(2);
+    expect(balances.reduce((a, b) => a + b, 0)).toBe(307_000);
   });
 });

--- a/apps/web-svelte/tests/unit/financial-surplus.spec.ts
+++ b/apps/web-svelte/tests/unit/financial-surplus.spec.ts
@@ -5,7 +5,26 @@ import {
   sumDebtMonthlyPayments,
   sumSaveMonthlyNeeded,
 } from "$lib/services/financial-surplus";
-import type { PlanDebtTerms } from "$lib/types";
+import type { Plan, PlanDebtTerms } from "$lib/types";
+
+const debtTerms = (planId: string, payment: number): PlanDebtTerms => ({
+  plan_id: planId,
+  original_amount: 200_000,
+  current_balance: 200_000,
+  annual_rate: 7,
+  monthly_payment: payment,
+  payment_day: null,
+  anchor_transaction_id: null,
+  created_at: "",
+  updated_at: "",
+});
+
+const debtPlan = (id: string, start: string, end: string): Pick<Plan, "id" | "kind" | "start_date" | "end_date"> => ({
+  id,
+  kind: "debt",
+  start_date: start,
+  end_date: end,
+});
 
 describe("computeMonthlySurplus", () => {
   it("uses month cashflow as the headline surplus", () => {
@@ -35,32 +54,18 @@ describe("computeMonthlySurplus", () => {
 });
 
 describe("sumDebtMonthlyPayments", () => {
-  it("sums monthly_payment across debt terms", () => {
-    const terms: Record<string, PlanDebtTerms> = {
-      a: {
-        plan_id: "a",
-        original_amount: 330000,
-        current_balance: 206000,
-        annual_rate: 7.18,
-        monthly_payment: 2370,
-        payment_day: null,
-        anchor_transaction_id: null,
-        created_at: "",
-        updated_at: "",
-      },
-      b: {
-        plan_id: "b",
-        original_amount: 50000,
-        current_balance: 40000,
-        annual_rate: 5,
-        monthly_payment: 900,
-        payment_day: null,
-        anchor_transaction_id: null,
-        created_at: "",
-        updated_at: "",
-      },
+  it("sums monthly_payment for active debt plans only", () => {
+    const plans = [
+      debtPlan("active", "2025-01-01", "2030-01-01"),
+      debtPlan("upcoming", "2026-09-01", "2046-09-01"),
+      debtPlan("finished", "2020-01-01", "2025-12-31"),
+    ];
+    const terms = {
+      active: debtTerms("active", 2370),
+      upcoming: debtTerms("upcoming", 2242),
+      finished: debtTerms("finished", 900),
     };
-    expect(sumDebtMonthlyPayments(terms)).toBe(3270);
+    expect(sumDebtMonthlyPayments(plans, terms, "2026-06-08")).toBe(2370);
   });
 });
 

--- a/apps/web-svelte/tests/unit/plan-settlement.spec.ts
+++ b/apps/web-svelte/tests/unit/plan-settlement.spec.ts
@@ -118,6 +118,18 @@ describe("computeSaveMonthlyActual", () => {
     });
     expect(actual).toBe(2000);
   });
+
+  it("returns zero for upcoming save goals", () => {
+    const actual = computeSaveMonthlyActual({
+      kind: "save",
+      startDate: "2026-12-01",
+      endDate: "2027-12-01",
+      savedAmount: 0,
+      linkedIncomes: [],
+      today: "2026-06-08",
+    });
+    expect(actual).toBe(0);
+  });
 });
 
 describe("computePlanProgress", () => {

--- a/apps/web-svelte/tests/unit/planning-queue.spec.ts
+++ b/apps/web-svelte/tests/unit/planning-queue.spec.ts
@@ -67,6 +67,87 @@ describe("buildPlanningQueueActions", () => {
     expect(actions.some((a) => a.id === "save-save-1")).toBe(true);
   });
 
+  it("ignores upcoming save goals for off-track chip", () => {
+    const actions = buildPlanningQueueActions({
+      summaries: [
+        summary({
+          id: "save-upcoming",
+          name: "Przyszły cel",
+          kind: "save",
+          bucket: "upcoming",
+          start_date: "2026-12-01",
+          end_date: "2027-12-01",
+          monthlyNeeded: 50_000,
+          monthlyActual: 0,
+        }),
+      ],
+      monthlySurplus: computeMonthlySurplus({
+        totalIncome: 8000,
+        totalExpenses: 3000,
+        debtMonthlyPayments: 0,
+        saveMonthlyNeeded: 0,
+      }),
+      debtTerms: {},
+    });
+    expect(actions.some((a) => a.id === "save-save-upcoming")).toBe(false);
+  });
+
+  it("debt chip uses active loans only", () => {
+    const debtTerms: Record<string, PlanDebtTerms> = {
+      "debt-active": {
+        plan_id: "debt-active",
+        original_amount: 100_000,
+        current_balance: 90_000,
+        annual_rate: 5,
+        monthly_payment: 1200,
+        payment_day: null,
+        anchor_transaction_id: null,
+        created_at: "",
+        updated_at: "",
+      },
+      "debt-future": {
+        plan_id: "debt-future",
+        original_amount: 200_000,
+        current_balance: 200_000,
+        annual_rate: 5,
+        monthly_payment: 2242,
+        payment_day: null,
+        anchor_transaction_id: null,
+        created_at: "",
+        updated_at: "",
+      },
+    };
+    const actions = buildPlanningQueueActions({
+      summaries: [
+        summary({
+          id: "debt-active",
+          kind: "debt",
+          bucket: "active",
+          start_date: "2025-01-01",
+          end_date: "2030-01-01",
+        }),
+        summary({
+          id: "debt-future",
+          kind: "debt",
+          bucket: "upcoming",
+          start_date: "2026-09-01",
+          end_date: "2046-09-01",
+        }),
+      ],
+      monthlySurplus: computeMonthlySurplus({
+        totalIncome: 5000,
+        totalExpenses: 4000,
+        debtMonthlyPayments: 1200,
+        saveMonthlyNeeded: 0,
+      }),
+      debtTerms,
+    });
+    const debtAction = actions.find((a) => a.id.startsWith("debt-"));
+    expect(debtAction).toBeDefined();
+    expect(debtAction?.label).not.toContain("2242");
+    expect(debtAction?.label).not.toContain("3 442");
+  });
+
   it("caps at three actions", () => {
     const debtTerms: Record<string, PlanDebtTerms> = {
       "debt-1": {

--- a/docs/product/debt-and-savings-goals.md
+++ b/docs/product/debt-and-savings-goals.md
@@ -68,7 +68,7 @@ po celach = bilans − suma monthlyNeeded aktywnych celów save
   goals; green/red card with tempo context.
 - Without save goals: informational copy that free surplus equals month cashflow.
 - Raty kredytów **nie** odejmujemy ponownie - przy import-first wydatków rata jest
-  już w wydatkach; karta pokazuje raty z planów tylko jako informację.
+  już w wydatkach; karta pokazuje raty **aktywnych** planów kredytowych tylko jako informację.
 - Save pace from `computePlanProgress().monthlyNeeded` on active save plans
   (`start_date ≤ today ≤ end_date`).
 - Subtle link to `/transactions` for drill-down.

--- a/docs/product/debt-and-savings-goals.md
+++ b/docs/product/debt-and-savings-goals.md
@@ -46,7 +46,10 @@ raty** / **Spłać / nadpłać** (debt).
 
 - `financial_snapshots`: one row per user - `cash_amount`, `investments_amount`,
   `real_estate_amount`, `as_of_date` (all manual entry).
-- **Majątek netto** on `/plans` = sum(assets) − sum(`plan_debt_terms.current_balance`).
+- **Majątek netto** on `/plans` = sum(assets) − sum(debt liabilities). Active loans use
+  accrued balance to the snapshot date; **upcoming (future) loans** count full
+  `original_amount`; finished loans drop out when balance is zero. If terms are not
+  saved yet, `plans.target_amount` is used as fallback.
 - Copy states values are user-entered; Portfelik does not derive bank balances from import.
 - **Pulpit strip (D2):** compact net-worth summary linking to `/plans`; same manual snapshot.
 


### PR DESCRIPTION
<!-- Auto-filled by scripts/open-pr.sh - do not hand-edit. -->
## Summary

- fix(plans): bucket-aware surplus, queue, and save pace
- Merge remote-tracking branch 'origin' into dev
- fix(net-worth): include upcoming debt plans in liability total
- feat(debt): year input, plan dates on edit, daily accrual

## Why

- Count only active debt raty in nadwyżka footnote; scope planning queue
- to group filter; skip upcoming/finished plans in queue chips and save pace.
- Co-authored-by: Cursor <cursoragent@cursor.com>
- Net worth now sums active and future loans explicitly: upcoming plans
- use full original_amount, active plans accrue to snapshot date, finished
- loans drop when paid off, and plans without terms fall back to target_amount.
- Co-authored-by: Cursor <cursoragent@cursor.com>
- Replace calendar year dropdown with a compact numeric field (up to 100
- years ahead for loan end dates). Debt edit panel adds Od/Koniec spłaty
- pickers saved with terms.
- Saldo and daily odsetki accrue from last terms update when no linked
- raty; hero shows accrued amount note. Amortization sims use effective
- balance.
- Co-authored-by: Cursor <cursoragent@cursor.com>

## Gates

- [x] `pnpm exec svelte-check --tsconfig ./tsconfig.json` is 0/0
- [x] `pnpm lint` is clean
- [x] `pnpm format:check` is clean
- [x] `pnpm test:unit` is green
- [x] RLS suite - not applicable (no schema/policy change)
- [x] Secret scan is clean

## Migrations

- [x] Not applicable

## Paraglide

- [x] Recompiled Paraglide (`messages/pl.json` changed)

## Branch Sync

- [x] Branch was synced from `origin/main` per `CLAUDE.md`