### PR TITLE
docs: tick closed items in 2026-06-09 product review (#129)

### DIFF
--- a/.claude/rules/svelte-gotchas.md
+++ b/.claude/rules/svelte-gotchas.md
@@ -12,7 +12,7 @@ paths:
 
 3. **PostgREST insert requires ALL NOT NULL columns.** Pass `user_id: user.id` explicitly from `supabase.auth.getUser()`. RLS does NOT auto-set it.
 
-4. **`complete_shopping_list` RPC returns a `transactions` row** (not void). Invalidate `shopping_list`, `transactions`, and `summary` query keys on success.
+4. **Plan settlement links existing transactions; it does NOT create financial truth.** `linkPlanTransaction`/`unlinkPlanTransaction` in `services/plan-settlement.ts` write `plan_transaction_links` only. Invalidate `plans`, `plan-links`, `plan-progress`, and (when status changes) `transactions` + `summary` query keys on success. (Legacy `complete_shopping_list` RPC is retired — Plans use first-class `plans` storage.)
 
 5. **Group writes are ALL SECURITY DEFINER RPCs.** Direct writes to `user_groups`, `group_members`, `group_invitations` blocked by `using (false)`. Use RPCs in `services/groups.ts`.
 

--- a/apps/web-svelte/CLAUDE.md
+++ b/apps/web-svelte/CLAUDE.md
@@ -22,7 +22,11 @@ Loaded automatically when working in `apps/web-svelte/`.
 - `transactions.ts` - `fetchTransactions(start, end, categoryId?)`, `computeSummary(txs)`, `createTransaction`, `updateTransaction`, `deleteTransaction`
 - `categories.ts` - `fetchCategories`, `createCategory`, `updateCategory`, `deleteCategory`
 - `groups.ts` - all group SECURITY DEFINER RPCs
-- `shopping-lists.ts` - current internal service for user-facing Plans; `fetchShoppingLists`, `fetchShoppingListById`, `fetchShoppingListItemHistory`, item CRUD, `completeShoppingList`, `duplicateShoppingList`
+- `plans.ts` - first-class Plans storage + lifecycle; `fetchPlans`, `fetchPlanById`, `createPlan`, `updatePlan`, `deletePlan`, `derivePlanBucket`, `canManagePlan`, save/debt date helpers
+- `plan-settlement.ts` - link/unlink transactions, `rankPlanTransaction`, `computePlanProgress`, `computeSaveMonthlyActual` / `computeSaveMonthlyActualDetail` (returns pace `basis`)
+- `plan-settlement-policy.ts` - settlement write-policy gates
+- `plan-debt.ts` - debt terms normalize/CRUD, `consolidateDebtLinkedPayments`, `deriveDebtBalanceFromLinks`; `debt-amortization.ts` - payoff/Belka scenarios
+- `planning-queue.ts` - surplus action cards; `financial-surplus.ts` - `computeMonthlySurplus` (`unreflectedDebt` / `debtAssumptionVerified`); `financial-snapshots.ts` - net-worth snapshots
 - `profiles.ts` - `fetchProfile`, `updateProfile`, `assignAdminRole`, `revokeAdminRole`
 - `notifications.ts` - `fetchNotifications`, `markNotificationRead`, `markAllNotificationsRead`, `deleteNotification`
 - `push.ts` - `registerServiceWorker`, `autoSubscribePush`, `requestAndSubscribePush`, `unsubscribeFromPush`
@@ -32,11 +36,12 @@ Loaded automatically when working in `apps/web-svelte/`.
 - `ui/` - `Dialog`, `ConfirmDialog`, `NotificationsPopover`
 - `transactions/` - `MonthRangePicker`, `CategoryFilter`, `TransactionTable` (shared tx badge, row click), `TransactionDialog`, `TransactionDetailSheet`, `SummaryCards`, `CategoryBreakdown` (clickable)
 - `settings/` - `CategoriesTab`, `GroupsTab`, `ProfileTab`, `CategoryDialog`
-- `shopping-lists/` - current internal components for user-facing Plans (`ShoppingListCard`, `ShoppingListSuggestions`, detail views)
+- `plans/` - first-class Plans UI (`PlanCard`, `SavePlanDetail`, `DebtPlanDetail`, `SurplusCard`, `NetWorthHero`, `PlanForwardNav`)
+- `dashboard/` - `DashboardImportHealth`, `DashboardNetWorthStrip`, `DashboardPlanProgress`
 
 **Utils** (`src/lib/utils.ts`): `cn`, `formatCurrency`, `formatDate`, `getMonthBounds`, `getDateRangeBounds`, `monthName`, `monthYearLabel`
 
-**Types** (`src/lib/types.ts`): `Transaction`, `TransactionWithCategory`, `TransactionStatus`, `TransactionType`, `MonthlySummary`, `CategorySummary`, `Category`, `Profile`, `UserGroup`, `GroupMember`, `GroupMemberWithProfile`, `GroupInvitation`, `ShoppingList`, `ShoppingListSummary`, `ShoppingListItem`, `ShoppingListWithItems`, `Notification`
+**Types** (`src/lib/types.ts`): `Transaction`, `TransactionWithCategory`, `TransactionStatus`, `TransactionType`, `MonthlySummary`, `CategorySummary`, `Category`, `Profile`, `UserGroup`, `GroupMember`, `GroupMemberWithProfile`, `GroupInvitation`, `Plan`, `PlanKind`, `PlanBucket`, `PlanSummary`, `PlanDebtTerms`, `FinancialSnapshot`, `Notification`
 
 **i18n**: `messages/pl.json` - always recompile after editing.
 

--- a/apps/web-svelte/e2e/helpers/fixtures.ts
+++ b/apps/web-svelte/e2e/helpers/fixtures.ts
@@ -61,6 +61,23 @@ export const MOCK_TRANSACTIONS = [
     created_at: "2026-05-02T10:00:00Z",
     updated_at: "2026-05-02T10:00:00Z",
   },
+  {
+    id: "tx-3",
+    date: "2026-05-15",
+    description: "Rachunek za prąd",
+    amount: 220,
+    type: "expense",
+    status: "upcoming",
+    category_id: "cat-1",
+    category_name: "Jedzenie",
+    is_recurring: false,
+    recurring_day: null,
+    currency: "PLN",
+    user_id: TEST_USER_ID,
+    group_id: null,
+    created_at: "2026-05-10T10:00:00Z",
+    updated_at: "2026-05-10T10:00:00Z",
+  },
 ];
 
 export const MOCK_NEW_TRANSACTION = {

--- a/apps/web-svelte/e2e/tests/transactions.spec.ts
+++ b/apps/web-svelte/e2e/tests/transactions.spec.ts
@@ -244,3 +244,14 @@ test("bulk delete: confirm and show success toast", async ({ page }) => {
   // Success toast - message: "Usunięto 2 transakcji"
   await expect(page.getByText(/Usunięto 2 transakcji/)).toBeVisible();
 });
+
+
+test("quick-settle marks an upcoming transaction paid", async ({ page }) => {
+  // tx-3 ("Rachunek za prąd") is seeded with status "upcoming" → eligible for quick-settle.
+  await expect(desktopTable(page).getByText("Rachunek za prąd")).toBeVisible();
+  const settle = page.getByRole("button", { name: "Oznacz jako zapłacone" }).first();
+  await expect(settle).toBeVisible();
+  await settle.click();
+  // Success toast confirms the mark-paid mutation fired with an undo affordance.
+  await expect(page.getByText("Oznaczono jako zapłacone")).toBeVisible();
+});

--- a/apps/web-svelte/messages/pl.json
+++ b/apps/web-svelte/messages/pl.json
@@ -815,6 +815,7 @@
   "plans_surplus_no_save_goals": "Bez aktywnych celów oszczędnościowych - bilans to wolna nadwyżka.",
   "plans_surplus_transactions_link": "Zobacz transakcje",
   "plans_surplus_debt_note": "Raty w planach {debt}/mies - zwykle już w wydatkach, jeśli importujesz transakcje.",
+  "plans_surplus_estimate_note": "≈ szacunek - zakładamy, że raty masz już w wydatkach",
   "dashboard_net_worth_title": "Majątek netto",
   "dashboard_net_worth_subtitle": "Stan na {date} · wpis ręczny",
   "dashboard_net_worth_empty": "Uzupełnij majątek w Plany.",
@@ -860,10 +861,13 @@
   "plan_save_gap_warning": "Brakuje {amount}/mies, by zdążyć na czas. Zwiększ wpłatę albo przesuń termin.",
   "plan_save_on_track": "Jesteś na dobrej drodze",
   "plan_save_on_track_badge": "na dobrej drodze",
+  "plan_save_on_track_estimate_badge": "≈ wg dotychczasowych wpłat",
   "plan_save_slider_target": "Budżet celu",
   "plan_save_slider_deadline": "Termin celu",
   "plan_save_deadline_urgent": "Termin jest już dziś lub za miesiąc - stąd wysoka kwota miesięczna. Przesuń termin albo zwiększ wpłaty.",
   "plan_save_slider_months": "za {count} mies.",
+  "plan_save_slider_months_duration": "{count} mies.",
+  "plan_save_slider_period": "{from} – {to}",
   "plan_save_link_cta": "Powiąż wpłaty",
   "plan_debt_remaining_hero": "Pozostało do spłaty",
   "plan_debt_balance_accrued_note": "+{amount} odsetek dziennie od {date} ({days} dni)",
@@ -944,5 +948,9 @@
   "group_filter_label": "Filtruj",
   "dashboard_plan_progress_error": "Nie udało się załadować planów.",
   "dashboard_plan_progress_all": "Wszystkie plany",
-  "transaction_detail_show_plan": "Plan"
+  "transaction_detail_show_plan": "Plan",
+  "transactions_quick_settle": "Oznacz jako zapłacone",
+  "transactions_quick_settle_short": "Zapłać",
+  "toast_transaction_settled": "Oznaczono jako zapłacone",
+  "toast_transaction_settle_undo": "Cofnij"
 }

--- a/apps/web-svelte/src/lib/components/Navigation.svelte
+++ b/apps/web-svelte/src/lib/components/Navigation.svelte
@@ -6,15 +6,9 @@
   import type { Profile } from "$lib/types";
   import type { User } from "@supabase/supabase-js";
   import * as m from "$lib/paraglide/messages";
-  import {
-    LayoutDashboard,
-    Wallet,
-    ShoppingBasket,
-    Settings,
-    ShieldCheck,
-    LogOut,
-  } from "lucide-svelte";
+  import { LayoutDashboard, Wallet, Target, Settings, ShieldCheck, LogOut } from "lucide-svelte";
   import NotificationsPopover from "$lib/components/ui/NotificationsPopover.svelte";
+  import { MediaQuery } from "svelte/reactivity";
 
   interface Props {
     profile: Profile | null;
@@ -22,17 +16,19 @@
   }
   let { profile, user }: Props = $props();
 
+  const isDesktopNav = new MediaQuery("(min-width: 768px)");
+
   // Mobile bottom nav keeps Panel (dashboard) centered.
   const navItems = [
     { href: "/transactions", label: m.nav_transactions(), icon: Wallet },
     { href: "/dashboard", label: m.nav_dashboard(), icon: LayoutDashboard },
-    { href: "/plans", label: m.nav_plans(), icon: ShoppingBasket },
+    { href: "/plans", label: m.nav_plans(), icon: Target },
   ];
 
   const desktopNavItems = [
     { href: "/dashboard", label: m.nav_dashboard(), icon: LayoutDashboard },
     { href: "/transactions", label: m.nav_transactions(), icon: Wallet },
-    { href: "/plans", label: m.nav_plans(), icon: ShoppingBasket },
+    { href: "/plans", label: m.nav_plans(), icon: Target },
   ];
 
   const isActive = (href: string) => $page.url.pathname.startsWith(href);
@@ -145,7 +141,9 @@
   </nav>
 
   <div class="relative ml-auto flex items-center gap-2">
-    <NotificationsPopover />
+    {#if isDesktopNav.current}
+      <NotificationsPopover placement="top" />
+    {/if}
     <button
       bind:this={menuButtonRef}
       type="button"
@@ -175,7 +173,9 @@
 >
   <span class="text-base font-semibold tracking-tight text-slate-100">{m.app_name()}</span>
   <div class="ml-auto">
-    <NotificationsPopover />
+    {#if !isDesktopNav.current}
+      <NotificationsPopover placement="bottom" />
+    {/if}
   </div>
   <button
     bind:this={menuButtonMobileRef}

--- a/apps/web-svelte/src/lib/components/plans/PlanCard.svelte
+++ b/apps/web-svelte/src/lib/components/plans/PlanCard.svelte
@@ -25,10 +25,16 @@
   );
   const debtPaidPct = $derived(
     debtTerms && debtTerms.original_amount > 0
-      ? Math.round(
-          ((Number(debtTerms.original_amount) - Number(debtTerms.current_balance)) /
-            Number(debtTerms.original_amount)) *
-            100
+      ? Math.min(
+          100,
+          Math.max(
+            0,
+            Math.round(
+              ((Number(debtTerms.original_amount) - Number(debtTerms.current_balance)) /
+                Number(debtTerms.original_amount)) *
+                100
+            )
+          )
         )
       : 0
   );
@@ -56,6 +62,12 @@
       plan.monthlyActual != null &&
       plan.monthlyActual >= plan.monthlyNeeded - 0.01
   );
+  // "historical-average" pace is an estimate from past deposits, not a demonstrated
+  // current-month rate — don't assert on-track confidently from it.
+  const saveOnTrackEstimate = $derived(
+    saveOnTrack && plan.monthlyActualBasis === "historical-average"
+  );
+  const saveOnTrackConfident = $derived(saveOnTrack && !saveOnTrackEstimate);
   const hasActions = $derived(!!onedit || !!ondelete);
 
   function suggestionLabel(count: number): string {
@@ -147,11 +159,18 @@
                   {m.plan_card_upcoming_badge()}
                 </span>
               {/if}
-              {#if saveOnTrack}
+              {#if saveOnTrackConfident}
                 <span
                   class="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-300 uppercase"
                 >
                   {m.plan_save_on_track_badge()}
+                </span>
+              {:else if saveOnTrackEstimate}
+                <span
+                  class="shrink-0 rounded-full border border-slate-500/30 bg-slate-500/10 px-2 py-0.5 text-[10px] font-medium text-slate-300 normal-case"
+                  title={m.plan_save_on_track_estimate_badge()}
+                >
+                  {m.plan_save_on_track_badge()} · {m.plan_save_on_track_estimate_badge()}
                 </span>
               {/if}
               {#if plan.group_id && groupName}
@@ -193,17 +212,15 @@
             <div class="bg-accent-gradient h-full rounded-full" style="width: {debtPaidPct}%"></div>
           </div>
           <div class="mt-1.5 flex items-center justify-between gap-2 text-xs">
-            <span class="text-slate-400">
+            <span class="min-w-0 truncate text-slate-400">
               {m.plan_debt_card_progress({
                 paid: formatCurrency(
                   Number(debtTerms.original_amount) - Number(debtTerms.current_balance)
                 ),
                 total: formatCurrency(Number(debtTerms.original_amount)),
-              })}
+              })} · {formatCurrency(Number(debtTerms.monthly_payment))}/mies
             </span>
-            <span class="text-slate-400 tabular-nums"
-              >{formatCurrency(Number(debtTerms.monthly_payment))}/mies</span
-            >
+            <span class="text-accent shrink-0 font-semibold tabular-nums">{debtPaidPct}%</span>
           </div>
         </div>
       {:else if plan.budget_amount != null}

--- a/apps/web-svelte/src/lib/components/plans/SavePlanDetail.svelte
+++ b/apps/web-svelte/src/lib/components/plans/SavePlanDetail.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import * as m from "$lib/paraglide/messages";
   import type { PlanSettlementProgress } from "$lib/services/plan-settlement";
-  import { addCalendarMonths, calendarMonthsUntil, todayIso } from "$lib/services/plans";
+  import {
+    addCalendarMonths,
+    derivePlanBucket,
+    savePlanDeadlineAnchor,
+    savePlanSliderMonths,
+  } from "$lib/services/plans";
   import type { Plan } from "$lib/types";
-  import { formatCurrency } from "$lib/utils";
+  import { formatCurrency, formatDate } from "$lib/utils";
   import { page } from "$app/stores";
   import PlanForwardNav from "$lib/components/plans/PlanForwardNav.svelte";
   import { planSettleHref } from "$lib/utils/plan-routes";
@@ -33,9 +38,15 @@
   let sliderTarget = $state(60000);
   let sliderMonths = $state(12);
 
+  const isUpcoming = $derived(derivePlanBucket(plan) === "upcoming");
+  const deadlineAnchor = $derived(savePlanDeadlineAnchor(plan));
+  const sliderEndPreview = $derived(addCalendarMonths(deadlineAnchor, sliderMonths));
+  const sliderMinMonths = $derived(isUpcoming ? 1 : 3);
+
   $effect(() => {
     sliderTarget = plan.target_amount ?? 60000;
-    sliderMonths = Math.max(3, calendarMonthsUntil(plan.end_date));
+    const months = savePlanSliderMonths(plan);
+    sliderMonths = Math.max(sliderMinMonths, months);
   });
 
   function emitTargetAdjust() {
@@ -43,7 +54,7 @@
   }
 
   function emitDeadlineAdjust() {
-    onAdjust?.({ end_date: addCalendarMonths(todayIso(), sliderMonths) });
+    onAdjust?.({ end_date: sliderEndPreview });
   }
 </script>
 
@@ -107,11 +118,23 @@
       <div>
         <div class="flex items-center justify-between text-xs text-slate-400">
           <span>{m.plan_save_slider_deadline()}</span>
-          <span class="text-slate-200">{m.plan_save_slider_months({ count: sliderMonths })}</span>
+          <span class="text-slate-200">
+            {#if isUpcoming}
+              {m.plan_save_slider_months_duration({ count: sliderMonths })}
+            {:else}
+              {m.plan_save_slider_months({ count: sliderMonths })}
+            {/if}
+          </span>
         </div>
+        <p class="mt-0.5 text-[11px] text-slate-500 tabular-nums">
+          {m.plan_save_slider_period({
+            from: formatDate(deadlineAnchor),
+            to: formatDate(sliderEndPreview),
+          })}
+        </p>
         <input
           type="range"
-          min="3"
+          min={sliderMinMonths}
           max="60"
           step="1"
           bind:value={sliderMonths}
@@ -138,6 +161,9 @@
         <p class="mt-1 text-sm font-semibold text-emerald-300 tabular-nums">
           {m.plan_save_monthly_actual({ amount: formatCurrency(progress.monthlyActual) })}
         </p>
+        {#if progress.monthlyActualBasis === "historical-average"}
+          <p class="mt-1 text-[11px] text-slate-500">{m.plan_save_on_track_estimate_badge()}</p>
+        {/if}
       </div>
     {/if}
   </div>

--- a/apps/web-svelte/src/lib/components/plans/SurplusCard.svelte
+++ b/apps/web-svelte/src/lib/components/plans/SurplusCard.svelte
@@ -41,6 +41,10 @@
     {/if}
   </p>
 
+  {#if summary.hasDebtPlans && !summary.debtAssumptionVerified}
+    <p class="mt-1 text-[11px] text-slate-500">{m.plans_surplus_estimate_note()}</p>
+  {/if}
+
   {#if actions.length > 0}
     <ul class="mt-4 space-y-2">
       {#each actions as action (action.id)}

--- a/apps/web-svelte/src/lib/components/transactions/TransactionTable.svelte
+++ b/apps/web-svelte/src/lib/components/transactions/TransactionTable.svelte
@@ -4,12 +4,14 @@
   import { cn, formatCurrency, formatDate } from "$lib/utils";
   import { ArrowDown, ArrowUp, ArrowUpDown, Check, Users, Wallet } from "lucide-svelte";
   import EmptyState from "$lib/components/ui/EmptyState.svelte";
+  import { isQuickSettleEligible } from "$lib/services/transaction-permissions";
 
   interface Props {
     transactions: TransactionWithCategory[];
     currentUserId?: string | null;
     ondelete?: (id: string) => void;
     onrowclick?: (tx: TransactionWithCategory) => void;
+    onsettle?: (tx: TransactionWithCategory) => void;
     emptyLabel?: string;
     emptyHint?: string;
     selectedIds?: Set<string>;
@@ -26,6 +28,7 @@
     transactions,
     ondelete,
     onrowclick,
+    onsettle,
     emptyLabel,
     emptyHint,
     selectedIds = $bindable(new Set<string>()),
@@ -42,6 +45,13 @@
   let sortDirection = $state<SortDirection>("desc");
 
   const isShared = (tx: TransactionWithCategory) => tx.group_id !== null;
+
+  /** Whole-row "button" semantics conflict with nested settle/checkbox controls (axe nested-interactive). */
+  function rowActsAsButton(tx: TransactionWithCategory): boolean {
+    if (!onrowclick || ondelete) return false;
+    if (onsettle && isQuickSettleEligible(tx.status) && canManage(tx)) return false;
+    return true;
+  }
 
   $effect(() => {
     void transactions;
@@ -226,11 +236,15 @@
                 onrowclick && "cursor-pointer hover:bg-white/5 active:scale-[0.99]",
                 selectedIds.has(tx.id) && "ring-2 ring-slate-400"
               )}
-              role={onrowclick && !ondelete ? "button" : undefined}
-              tabindex={onrowclick ? 0 : undefined}
+              role={rowActsAsButton(tx) ? "button" : undefined}
+              tabindex={rowActsAsButton(tx) ? 0 : undefined}
               onclick={() => onrowclick?.(tx)}
               onkeydown={(e) => {
-                if (e.key === "Enter" || e.key === " ") onrowclick?.(tx);
+                if (!rowActsAsButton(tx)) return;
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onrowclick?.(tx);
+                }
               }}
             >
               <div class="flex items-start justify-between gap-3">
@@ -305,6 +319,20 @@
                 >
                   {statusLabel[tx.status] ?? tx.status}
                 </span>
+                {#if onsettle && isQuickSettleEligible(tx.status) && canManage(tx)}
+                  <button
+                    type="button"
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      onsettle?.(tx);
+                    }}
+                    class="focus-visible:ring-accent inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-500/20 focus-visible:ring-2 focus-visible:outline-none"
+                    aria-label={m.transactions_quick_settle()}
+                  >
+                    <Check size={11} strokeWidth={2.5} aria-hidden="true" />
+                    {m.transactions_quick_settle_short()}
+                  </button>
+                {/if}
               </div>
             </li>
           {/each}
@@ -412,11 +440,15 @@
                 !!onrowclick && "cursor-pointer",
                 selectedIds.has(tx.id) && "bg-white/5"
               )}
-              role={onrowclick && !ondelete ? "button" : undefined}
-              tabindex={onrowclick ? 0 : undefined}
+              role={rowActsAsButton(tx) ? "button" : undefined}
+              tabindex={rowActsAsButton(tx) ? 0 : undefined}
               onclick={() => onrowclick?.(tx)}
               onkeydown={(e) => {
-                if (e.key === "Enter" || e.key === " ") onrowclick?.(tx);
+                if (!rowActsAsButton(tx)) return;
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onrowclick?.(tx);
+                }
               }}
             >
               {#if ondelete && canManage(tx)}
@@ -476,6 +508,20 @@
                 >
                   {statusLabel[tx.status] ?? tx.status}
                 </span>
+                {#if onsettle && isQuickSettleEligible(tx.status) && canManage(tx)}
+                  <button
+                    type="button"
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      onsettle?.(tx);
+                    }}
+                    class="focus-visible:ring-accent inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-500/20 focus-visible:ring-2 focus-visible:outline-none"
+                    aria-label={m.transactions_quick_settle()}
+                  >
+                    <Check size={11} strokeWidth={2.5} aria-hidden="true" />
+                    {m.transactions_quick_settle_short()}
+                  </button>
+                {/if}
               </td>
               <td
                 class={cn(

--- a/apps/web-svelte/src/lib/components/ui/NotificationsPopover.svelte
+++ b/apps/web-svelte/src/lib/components/ui/NotificationsPopover.svelte
@@ -11,6 +11,7 @@
     markAllNotificationsRead,
     deleteNotification,
   } from "$lib/services/notifications";
+  import { notifyNotificationsChanged } from "$lib/services/notification-sync";
   import { formatDate } from "$lib/utils";
   import type { Notification } from "$lib/types";
   import { notificationTargetHref } from "$lib/notification-targets";
@@ -44,22 +45,22 @@
 
   const markReadMutation = createMutation(() => ({
     mutationFn: (id: string) => markNotificationRead(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+    onSuccess: () => notifyNotificationsChanged(queryClient),
   }));
 
   const markUnreadMutation = createMutation(() => ({
     mutationFn: (id: string) => markNotificationUnread(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+    onSuccess: () => notifyNotificationsChanged(queryClient),
   }));
 
   const markAllMutation = createMutation(() => ({
     mutationFn: markAllNotificationsRead,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+    onSuccess: () => notifyNotificationsChanged(queryClient),
   }));
 
   const deleteMutation = createMutation(() => ({
     mutationFn: (id: string) => deleteNotification(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+    onSuccess: () => notifyNotificationsChanged(queryClient),
   }));
 
   function handleOpen() {

--- a/apps/web-svelte/src/lib/services/financial-snapshots.ts
+++ b/apps/web-svelte/src/lib/services/financial-snapshots.ts
@@ -32,13 +32,17 @@ export function computeNetWorth(
   };
 }
 
-/** Balance for one debt plan in net-worth (active + upcoming; finished only if balance remains). */
+/** Balance for one active debt plan in net-worth (finished only if balance remains). */
 export function debtBalanceForNetWorth(
   plan: Pick<Plan, "start_date" | "end_date" | "target_amount">,
   terms: PlanDebtTerms | undefined,
   asOfDate = todayIso()
 ): number {
   const bucket = derivePlanBucket(plan, asOfDate);
+
+  if (bucket === "upcoming") {
+    return 0;
+  }
 
   if (bucket === "finished") {
     if (!terms) return 0;
@@ -47,10 +51,6 @@ export function debtBalanceForNetWorth(
   }
 
   if (terms) {
-    if (bucket === "upcoming") {
-      // Future loan: full principal obligation counts toward net worth today.
-      return Math.max(Number(terms.current_balance), Number(terms.original_amount));
-    }
     const anchor = terms.updated_at.slice(0, 10);
     return accrueBalanceWithDailyInterest(
       Number(terms.current_balance),
@@ -60,7 +60,7 @@ export function debtBalanceForNetWorth(
     );
   }
 
-  // Plan exists but terms not saved yet — use target_amount from create form.
+  // Active plan without terms row yet — use target_amount from create form.
   const fallback = plan.target_amount != null ? Number(plan.target_amount) : 0;
   return fallback > 0.01 ? fallback : 0;
 }

--- a/apps/web-svelte/src/lib/services/financial-surplus.ts
+++ b/apps/web-svelte/src/lib/services/financial-surplus.ts
@@ -9,6 +9,14 @@ export interface MonthlySurplusInput {
   totalExpenses: number;
   debtMonthlyPayments: number;
   saveMonthlyNeeded: number;
+  /**
+   * Portion of `debtMonthlyPayments` actually observed inside `totalExpenses` this month
+   * (e.g. detected/linked debt-payment transactions). Omit when unknown — the surplus is
+   * then flagged `debtAssumptionVerified: false` and the headline assumes raty already sit
+   * in expenses (legacy behaviour). When supplied, any shortfall is treated as an obligation
+   * not yet reflected in the cashflow and is subtracted from `afterSaveGoals`.
+   */
+  debtPaymentsInExpenses?: number;
 }
 
 export interface MonthlySurplusSummary {
@@ -19,20 +27,34 @@ export interface MonthlySurplusSummary {
   saveMonthlyNeeded: number;
   /** Month cashflow (income − expenses). Raty kredytów nie odejmujemy ponownie - są już w wydatkach. */
   surplus: number;
-  /** Cashflow minus save-goal pace (when user tracks accumulation targets). */
+  /** Cashflow minus save-goal pace minus any debt obligation not reflected in expenses. */
   afterSaveGoals: number;
+  /** Debt obligation NOT observed inside expenses (subtracted from afterSaveGoals). */
+  unreflectedDebt: number;
+  /** True only when the caller supplied observed debt coverage; false = assumption unchecked. */
+  debtAssumptionVerified: boolean;
   hasSaveGoals: boolean;
   hasDebtPlans: boolean;
 }
 
 export function computeMonthlySurplus(input: MonthlySurplusInput): MonthlySurplusSummary {
   const cashflowNet = input.totalIncome - input.totalExpenses;
-  const afterSaveGoals = cashflowNet - input.saveMonthlyNeeded;
+  // When coverage is unknown, assume the full payment is already inside expenses
+  // (legacy behaviour) but flag the result as unverified so the UI can mark it an estimate.
+  const debtAssumptionVerified = input.debtPaymentsInExpenses !== undefined;
+  const observed = input.debtPaymentsInExpenses ?? input.debtMonthlyPayments;
+  const unreflectedDebt = Math.max(0, input.debtMonthlyPayments - observed);
+  const afterSaveGoals = cashflowNet - input.saveMonthlyNeeded - unreflectedDebt;
   return {
-    ...input,
+    totalIncome: input.totalIncome,
+    totalExpenses: input.totalExpenses,
+    debtMonthlyPayments: input.debtMonthlyPayments,
+    saveMonthlyNeeded: input.saveMonthlyNeeded,
     cashflowNet,
     surplus: cashflowNet,
     afterSaveGoals,
+    unreflectedDebt,
+    debtAssumptionVerified,
     hasSaveGoals: input.saveMonthlyNeeded > 0,
     hasDebtPlans: input.debtMonthlyPayments > 0,
   };

--- a/apps/web-svelte/src/lib/services/notification-sync.ts
+++ b/apps/web-svelte/src/lib/services/notification-sync.ts
@@ -1,0 +1,72 @@
+import type { QueryClient } from "@tanstack/svelte-query";
+
+/** Shared with static/sw.js — keep in sync when renaming. */
+export const NOTIFICATION_SYNC_CHANNEL = "portfelik-notifications";
+
+/** postMessage type from the service worker to open tabs. */
+export const SW_NOTIFICATION_MESSAGE_TYPE = "portfelik:notification";
+
+export type NotificationSyncPayload = { type: "invalidate" };
+
+export type ForegroundPushPayload = {
+  title: string;
+  body: string;
+  notificationId?: string;
+};
+
+export function broadcastNotificationSync(payload: NotificationSyncPayload): void {
+  if (typeof BroadcastChannel === "undefined") return;
+  try {
+    const channel = new BroadcastChannel(NOTIFICATION_SYNC_CHANNEL);
+    channel.postMessage(payload);
+    channel.close();
+  } catch {
+    // Private mode / unsupported — local invalidate still runs.
+  }
+}
+
+/** Invalidate the bell in this tab and notify other open tabs. */
+export function notifyNotificationsChanged(queryClient: QueryClient): void {
+  void queryClient.invalidateQueries({ queryKey: ["notifications"] });
+  broadcastNotificationSync({ type: "invalidate" });
+}
+
+export function setupNotificationSync(
+  queryClient: QueryClient,
+  onForegroundPush?: (payload: ForegroundPushPayload) => void
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const channel =
+    typeof BroadcastChannel !== "undefined"
+      ? new BroadcastChannel(NOTIFICATION_SYNC_CHANNEL)
+      : null;
+
+  const onChannelMessage = (event: MessageEvent<NotificationSyncPayload>) => {
+    if (event.data?.type === "invalidate") {
+      void queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    }
+  };
+
+  channel?.addEventListener("message", onChannelMessage);
+
+  const onServiceWorkerMessage = (event: MessageEvent) => {
+    const data = event.data;
+    if (!data || data.type !== SW_NOTIFICATION_MESSAGE_TYPE) return;
+
+    void queryClient.invalidateQueries({ queryKey: ["notifications"] });
+
+    const payload = data.payload as ForegroundPushPayload | undefined;
+    if (payload?.title && document.hasFocus() && onForegroundPush) {
+      onForegroundPush(payload);
+    }
+  };
+
+  navigator.serviceWorker?.addEventListener("message", onServiceWorkerMessage);
+
+  return () => {
+    channel?.removeEventListener("message", onChannelMessage);
+    channel?.close();
+    navigator.serviceWorker?.removeEventListener("message", onServiceWorkerMessage);
+  };
+}

--- a/apps/web-svelte/src/lib/services/plan-debt.ts
+++ b/apps/web-svelte/src/lib/services/plan-debt.ts
@@ -48,22 +48,29 @@ export function applyDebtPaymentPeriod(
   return Math.max(0, balance - principal);
 }
 
-/** Collapse linked expenses into ordered payment amounts (one period per calendar month when dated). */
+/**
+ * Collapse linked expenses into ordered payment periods.
+ * Dated rows are grouped by calendar month (ascending) — one interest period per month —
+ * even when other rows are undated. Undated rows have unknown timing, so each stays its own
+ * period and they are applied AFTER all dated months, in input order. The result is fully
+ * deterministic regardless of the order linked expenses arrive in.
+ */
 export function consolidateDebtLinkedPayments(linkedExpenses: DebtLinkedPayment[]): number[] {
   if (linkedExpenses.length === 0) return [];
-  const dated = linkedExpenses.filter((e) => e.date?.slice(0, 7));
-  if (dated.length === linkedExpenses.length) {
-    const byMonth = new Map<string, number>();
-    for (const exp of linkedExpenses) {
-      const key = exp.date!.slice(0, 7);
-      byMonth.set(key, (byMonth.get(key) ?? 0) + Math.abs(exp.amount));
+  const byMonth = new Map<string, number>();
+  const undated: number[] = [];
+  for (const exp of linkedExpenses) {
+    const month = exp.date?.slice(0, 7);
+    if (month) {
+      byMonth.set(month, (byMonth.get(month) ?? 0) + Math.abs(exp.amount));
+    } else {
+      undated.push(Math.abs(exp.amount));
     }
-    return [...byMonth.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([, sum]) => sum);
   }
-  const sorted = [...linkedExpenses].sort((a, b) =>
-    (a.date?.slice(0, 10) ?? "").localeCompare(b.date?.slice(0, 10) ?? "")
-  );
-  return sorted.map((e) => Math.abs(e.amount));
+  const datedPeriods = [...byMonth.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, sum]) => sum);
+  return [...datedPeriods, ...undated];
 }
 
 /**

--- a/apps/web-svelte/src/lib/services/plan-settlement.ts
+++ b/apps/web-svelte/src/lib/services/plan-settlement.ts
@@ -38,6 +38,10 @@ export interface PlanSettlementProgress {
   eligibleCount: number;
   monthlyNeeded: number | null;
   monthlyActual: number | null;
+  monthlyActualBasis: SavePaceBasis;
+  /** Sum of paid linked EXPENSE transactions dated in the current calendar month
+      (debt-payment coverage actually present in this month's tracked expenses). */
+  linkedExpenseCurrentMonth: number;
   monthsRemaining: number | null;
 }
 
@@ -266,6 +270,53 @@ function sumLinkedIncomeInMonth(
     .reduce((sum, t) => sum + t.amount, 0);
 }
 
+export type SavePaceBasis = "none" | "current-month" | "historical-average";
+
+export interface SaveMonthlyActualDetail {
+  /** null when the plan is not a save plan. */
+  amount: number | null;
+  /**
+   * How `amount` was derived:
+   * - "current-month": real deposits linked this calendar month (demonstrated pace),
+   * - "historical-average": savedAmount averaged over elapsed months (an estimate — a single
+   *   upfront lump sum inflates this and must not be presented as sustained ongoing pace),
+   * - "none": not a save plan, not active, or nothing saved yet.
+   */
+  basis: SavePaceBasis;
+}
+
+export function computeSaveMonthlyActualDetail(input: {
+  kind?: import("$lib/types").PlanKind;
+  startDate?: string;
+  endDate?: string;
+  savedAmount: number;
+  linkedIncomes: TransactionWithCategory[];
+  today?: string;
+}): SaveMonthlyActualDetail {
+  if (input.kind !== "save") return { amount: null, basis: "none" };
+  const today = input.today ?? todayIso();
+  if (
+    input.startDate &&
+    input.endDate &&
+    derivePlanBucket({ start_date: input.startDate, end_date: input.endDate }, today) !== "active"
+  ) {
+    return { amount: 0, basis: "none" };
+  }
+  const bounds = currentCalendarMonthBounds(new Date(today));
+  const currentMonthDeposits = sumLinkedIncomeInMonth(
+    input.linkedIncomes,
+    bounds.start,
+    bounds.end
+  );
+  if (currentMonthDeposits > 0) return { amount: currentMonthDeposits, basis: "current-month" };
+  if (input.savedAmount <= 0) return { amount: 0, basis: "none" };
+  const elapsedMonths = input.startDate ? monthsBetween(input.startDate, today) : 1;
+  return {
+    amount: input.savedAmount / Math.max(1, elapsedMonths),
+    basis: "historical-average",
+  };
+}
+
 export function computeSaveMonthlyActual(input: {
   kind?: import("$lib/types").PlanKind;
   startDate?: string;
@@ -274,25 +325,7 @@ export function computeSaveMonthlyActual(input: {
   linkedIncomes: TransactionWithCategory[];
   today?: string;
 }): number | null {
-  if (input.kind !== "save") return null;
-  const today = input.today ?? todayIso();
-  if (
-    input.startDate &&
-    input.endDate &&
-    derivePlanBucket({ start_date: input.startDate, end_date: input.endDate }, today) !== "active"
-  ) {
-    return 0;
-  }
-  const bounds = currentCalendarMonthBounds(new Date(today));
-  const currentMonthDeposits = sumLinkedIncomeInMonth(
-    input.linkedIncomes,
-    bounds.start,
-    bounds.end
-  );
-  if (currentMonthDeposits > 0) return currentMonthDeposits;
-  if (input.savedAmount <= 0) return 0;
-  const elapsedMonths = input.startDate ? monthsBetween(input.startDate, today) : 1;
-  return input.savedAmount / Math.max(1, elapsedMonths);
+  return computeSaveMonthlyActualDetail(input).amount;
 }
 
 export function computePlanProgress(input: {
@@ -313,6 +346,13 @@ export function computePlanProgress(input: {
   const incomes = paidLinked.filter((t) => t.type === "income");
   const spentAmount = expenses.reduce((s, t) => s + t.amount, 0);
   const incomeAmount = incomes.reduce((s, t) => s + t.amount, 0);
+  const monthBounds = currentCalendarMonthBounds(new Date(today));
+  const linkedExpenseCurrentMonth = expenses
+    .filter((t) => {
+      const d = t.date.slice(0, 10);
+      return d >= monthBounds.start && d <= monthBounds.end;
+    })
+    .reduce((sum, t) => sum + t.amount, 0);
   const savedAmount = incomeAmount;
   const targetAmount = input.targetAmount ?? null;
   const remaining =
@@ -331,7 +371,7 @@ export function computePlanProgress(input: {
     isActive && targetAmount != null && targetAmount > 0 && monthsRem != null && monthsRem > 0
       ? Math.max(0, (targetAmount - savedAmount) / monthsRem)
       : null;
-  const monthlyActual = computeSaveMonthlyActual({
+  const monthlyActualDetail = computeSaveMonthlyActualDetail({
     kind: input.kind,
     startDate: input.startDate,
     endDate: input.endDate,
@@ -339,6 +379,7 @@ export function computePlanProgress(input: {
     linkedIncomes: incomes,
     today,
   });
+  const monthlyActual = monthlyActualDetail.amount;
   return {
     planId: input.planId,
     planName: input.planName,
@@ -355,6 +396,8 @@ export function computePlanProgress(input: {
     eligibleCount: input.eligibleCount ?? 0,
     monthlyNeeded,
     monthlyActual,
+    monthlyActualBasis: monthlyActualDetail.basis,
+    linkedExpenseCurrentMonth,
     monthsRemaining: monthsRem,
   };
 }

--- a/apps/web-svelte/src/lib/services/planning-queue.ts
+++ b/apps/web-svelte/src/lib/services/planning-queue.ts
@@ -49,6 +49,10 @@ export function buildPlanningQueueActions(input: {
     });
   }
 
+  // Only demonstrated current-month deposits count as keeping pace. A historical-average
+  // estimate (or no deposits this month) must not suppress the warn chip.
+  const currentMonthPace = (p: PlanSummary): number =>
+    p.monthlyActualBasis === "current-month" ? (p.monthlyActual ?? 0) : 0;
   const offTrackSave = summaries
     .filter(
       (p) =>
@@ -56,7 +60,7 @@ export function buildPlanningQueueActions(input: {
         p.bucket === "active" &&
         p.monthlyNeeded != null &&
         p.monthlyNeeded > 0 &&
-        (p.monthlyActual ?? 0) < p.monthlyNeeded - 0.01
+        currentMonthPace(p) < p.monthlyNeeded - 0.01
     )
     .sort((a, b) => (b.monthlyNeeded ?? 0) - (a.monthlyNeeded ?? 0));
   if (offTrackSave[0]) {

--- a/apps/web-svelte/src/lib/services/plans.ts
+++ b/apps/web-svelte/src/lib/services/plans.ts
@@ -22,14 +22,30 @@ export function addCalendarMonths(anchor: string, months: number): string {
   return formatLocalDate(d);
 }
 
-/** Whole calendar months from today until endDate (inverse of addCalendarMonths). */
-export function calendarMonthsUntil(endDate: string, today = todayIso()): number {
+/** Whole calendar months from anchor until endDate (inverse of addCalendarMonths). */
+export function calendarMonthsUntil(endDate: string, anchor = todayIso()): number {
   const end = parseLocalDate(endDate);
-  const now = parseLocalDate(today);
-  if (end < now) return 0;
-  let months = (end.getFullYear() - now.getFullYear()) * 12 + (end.getMonth() - now.getMonth());
-  if (end.getDate() < now.getDate()) months -= 1;
+  const start = parseLocalDate(anchor);
+  if (end < start) return 0;
+  let months = (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+  if (end.getDate() < start.getDate()) months -= 1;
   return Math.max(1, months);
+}
+
+/** Save-goal deadline slider anchor: plan start when upcoming, else today. */
+export function savePlanDeadlineAnchor(
+  plan: Pick<Plan, "start_date" | "end_date">,
+  today = todayIso()
+): string {
+  return derivePlanBucket(plan, today) === "upcoming" ? plan.start_date : today;
+}
+
+/** Months shown on the save-goal deadline slider (start→end or today→end). */
+export function savePlanSliderMonths(
+  plan: Pick<Plan, "start_date" | "end_date">,
+  today = todayIso()
+): number {
+  return calendarMonthsUntil(plan.end_date, savePlanDeadlineAnchor(plan, today));
 }
 
 export function defaultDebtPlanEndDate(today = todayIso()): string {

--- a/apps/web-svelte/src/lib/services/transaction-permissions.ts
+++ b/apps/web-svelte/src/lib/services/transaction-permissions.ts
@@ -1,4 +1,9 @@
-import type { GroupMemberRole, TransactionWithCategory } from "$lib/types";
+import type { GroupMemberRole, TransactionStatus, TransactionWithCategory } from "$lib/types";
+
+/** Rows that quick-settle ("mark paid") can act on — a planned/overdue obligation, not yet settled. */
+export function isQuickSettleEligible(status: TransactionStatus): boolean {
+  return status === "upcoming" || status === "overdue";
+}
 
 /** Mirrors transaction RLS: creator or group owner/co-owner may write. */
 export function canManageTransaction(

--- a/apps/web-svelte/src/lib/types.ts
+++ b/apps/web-svelte/src/lib/types.ts
@@ -173,6 +173,8 @@ export interface PlanSummary extends Plan {
   eligibleCount: number;
   monthlyNeeded: number | null;
   monthlyActual: number | null;
+  /** How monthlyActual was derived — "historical-average" is an estimate, not demonstrated pace. */
+  monthlyActualBasis?: "none" | "current-month" | "historical-average";
   bucket: PlanBucket;
 }
 

--- a/apps/web-svelte/src/routes/+layout.svelte
+++ b/apps/web-svelte/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
   import * as m from "$lib/paraglide/messages";
   import { fetchProfile } from "$lib/services/profiles";
   import { applyAccent } from "$lib/theme/accent-presets";
+  import { setupNotificationSync } from "$lib/services/notification-sync";
   import {
     autoSubscribePush,
     registerServiceWorker,
@@ -25,6 +26,7 @@
   import type { User } from "@supabase/supabase-js";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import { onMount } from "svelte";
+  import { toast } from "svelte-sonner";
   import { Toaster } from "svelte-sonner";
   import { fade } from "svelte/transition";
   import "../app.css";
@@ -133,9 +135,13 @@
     registerServiceWorker().then(() => autoSubscribePush(authUser.id).catch(() => {}));
   }
 
-  onMount(async () => {
+  onMount(() => {
     if ("Notification" in window) notifPermission = Notification.permission;
     readPushPromptCooldown();
+
+    const teardownNotificationSync = setupNotificationSync(queryClient, ({ title, body }) => {
+      toast(title, { description: body || undefined });
+    });
 
     supabase.auth.onAuthStateChange((event, session) => {
       if (event === "SIGNED_OUT") {
@@ -152,25 +158,31 @@
       }
     });
 
-    const bootstrapRevision = authRevision;
-    const {
-      data: { user: authUser },
-      error: userError,
-    } = await supabase.auth.getUser();
+    void (async () => {
+      const bootstrapRevision = authRevision;
+      const {
+        data: { user: authUser },
+        error: userError,
+      } = await supabase.auth.getUser();
 
-    // A sign-in (or sign-out) landed while getUser() was in flight - its result
-    // is authoritative, so discard this now-stale bootstrap snapshot.
-    if (bootstrapRevision !== authRevision) return;
+      // A sign-in (or sign-out) landed while getUser() was in flight - its result
+      // is authoritative, so discard this now-stale bootstrap snapshot.
+      if (bootstrapRevision !== authRevision) return;
 
-    if (userError || !authUser) {
-      clearAuthenticatedUser();
-    } else {
-      loadAuthenticatedUser(authUser);
-    }
+      if (userError || !authUser) {
+        clearAuthenticatedUser();
+      } else {
+        loadAuthenticatedUser(authUser);
+      }
 
-    if (!authUser && !isPublicRoute) {
-      redirectToLogin();
-    }
+      if (!authUser && !isPublicRoute) {
+        redirectToLogin();
+      }
+    })();
+
+    return () => {
+      teardownNotificationSync();
+    };
   });
 </script>
 

--- a/apps/web-svelte/src/routes/dashboard/+page.svelte
+++ b/apps/web-svelte/src/routes/dashboard/+page.svelte
@@ -8,15 +8,17 @@
   import CategoryBreakdown from "$lib/components/transactions/CategoryBreakdown.svelte";
   import * as m from "$lib/paraglide/messages";
   import { fetchProfile } from "$lib/services/profiles";
-  import { fetchUserGroups } from "$lib/services/groups";
+  import { fetchMyGroupRoles, fetchUserGroups } from "$lib/services/groups";
   import {
     computeForecastSummary,
     computeLedgerSummary,
     ledgerTransactions,
   } from "$lib/services/transaction-cashflow";
-  import { fetchTransactions } from "$lib/services/transactions";
+  import { fetchTransactions, updateTransactionsStatus } from "$lib/services/transactions";
+  import { canManageTransaction } from "$lib/services/transaction-permissions";
+  import { toast } from "svelte-sonner";
   import { supabase } from "$lib/supabase";
-  import type { TransactionWithCategory } from "$lib/types";
+  import type { TransactionStatus, TransactionWithCategory } from "$lib/types";
   import { cn, formatCurrency, getDateRangeBounds } from "$lib/utils";
   import { syncListViewUrl } from "$lib/utils/navigation";
   import {
@@ -25,7 +27,7 @@
     type DashboardPeriod,
     type ScopeFilter,
   } from "$lib/utils/list-view-url";
-  import { createQuery } from "@tanstack/svelte-query";
+  import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { onMount } from "svelte";
   import { dailyGreeting, dailyQuote } from "$lib/dashboard-daily";
 
@@ -86,6 +88,42 @@
     const { data } = await supabase.auth.getSession();
     userId = data.session?.user.id ?? null;
   });
+
+  const queryClient = useQueryClient();
+
+  const groupRolesQuery = createQuery(() => ({
+    queryKey: ["group_roles"],
+    queryFn: fetchMyGroupRoles,
+    enabled: !!userId,
+  }));
+
+  function dashCanManage(tx: TransactionWithCategory): boolean {
+    if (!userId) return false;
+    return canManageTransaction(tx, userId, groupRolesQuery.data ?? new Map());
+  }
+
+  const settleMutation = createMutation(() => ({
+    mutationFn: (vars: { id: string; prev: TransactionStatus }) =>
+      updateTransactionsStatus([vars.id], "paid"),
+    onSuccess: async (_data, vars) => {
+      await queryClient.invalidateQueries({ queryKey: ["transactions"] });
+      toast.success(m.toast_transaction_settled(), {
+        action: {
+          label: m.toast_transaction_settle_undo(),
+          onClick: () => {
+            void updateTransactionsStatus([vars.id], vars.prev).then(() =>
+              queryClient.invalidateQueries({ queryKey: ["transactions"] })
+            );
+          },
+        },
+      });
+    },
+    onError: () => toast.error(m.toast_error()),
+  }));
+
+  function quickSettle(tx: TransactionWithCategory) {
+    settleMutation.mutate({ id: tx.id, prev: tx.status });
+  }
 
   const profileQuery = createQuery(() => ({
     queryKey: ["profile", userId],
@@ -491,7 +529,10 @@
       <TransactionTable
         transactions={upcomingTxs}
         selectedIds={new Set()}
+        currentUserId={userId}
+        canManage={dashCanManage}
         onrowclick={openTransaction}
+        onsettle={quickSettle}
       />
     {/if}
   </div>

--- a/apps/web-svelte/src/routes/plans/+page.svelte
+++ b/apps/web-svelte/src/routes/plans/+page.svelte
@@ -173,6 +173,7 @@
         eligibleCount: progress?.eligibleCount ?? 0,
         monthlyNeeded: progress?.monthlyNeeded ?? null,
         monthlyActual: progress?.monthlyActual ?? null,
+        monthlyActualBasis: progress?.monthlyActualBasis,
         bucket: derivePlanBucket(plan),
       };
     })
@@ -212,11 +213,19 @@
   const monthlySurplus = $derived.by(() => {
     const monthSummary = monthTxQuery.data ? computeLedgerSummary(scopedMonthTxs) : null;
     if (!monthSummary) return null;
+    // Observed debt-payment coverage: sum of current-month linked expenses across active debt
+    // plans. Only pass it once progress has loaded; until then the surplus stays an estimate.
+    const debtPaymentsInExpenses = progressQuery.data
+      ? scopedSummaries
+          .filter((p) => p.kind === "debt" && p.bucket === "active")
+          .reduce((sum, p) => sum + (progressQuery.data?.[p.id]?.linkedExpenseCurrentMonth ?? 0), 0)
+      : undefined;
     return computeMonthlySurplus({
       totalIncome: monthSummary.total_income,
       totalExpenses: monthSummary.total_expenses,
       debtMonthlyPayments: sumDebtMonthlyPayments(scopedSummaries, scopedDebtTerms),
       saveMonthlyNeeded: sumSaveMonthlyNeeded(scopedSummaries),
+      debtPaymentsInExpenses,
     });
   });
 

--- a/apps/web-svelte/src/routes/transactions/+page.svelte
+++ b/apps/web-svelte/src/routes/transactions/+page.svelte
@@ -28,6 +28,8 @@
     updateTransactionsStatus,
   } from "$lib/services/transactions";
   import { supabase } from "$lib/supabase";
+  import { parseScopeFilter } from "$lib/utils/list-view-url";
+  import { syncListViewUrl } from "$lib/utils/navigation";
   import type { TransactionStatus, TransactionWithCategory } from "$lib/types";
   import {
     cn,
@@ -166,7 +168,7 @@
 
   const statusSet = $derived(statusFilter ? new Set(statusFilter.split(",")) : null);
 
-  let groupFilter = $state<"all" | "own" | string>("all");
+  const groupFilter = $derived(parseScopeFilter($page.url.searchParams));
 
   // filteredTxs: applies BOTH status filter AND group filter so it's the
   // canonical "what the user is looking at" set used by summary,
@@ -386,6 +388,29 @@
     },
     onError: () => toast.error(m.toast_error()),
   }));
+
+  const settleMutation = createMutation(() => ({
+    mutationFn: (vars: { id: string; prev: TransactionStatus }) =>
+      updateTransactionsStatus([vars.id], "paid"),
+    onSuccess: async (_data, vars) => {
+      await queryClient.invalidateQueries({ queryKey: ["transactions"] });
+      toast.success(m.toast_transaction_settled(), {
+        action: {
+          label: m.toast_transaction_settle_undo(),
+          onClick: () => {
+            void updateTransactionsStatus([vars.id], vars.prev).then(() =>
+              queryClient.invalidateQueries({ queryKey: ["transactions"] })
+            );
+          },
+        },
+      });
+    },
+    onError: () => toast.error(m.toast_error()),
+  }));
+
+  function quickSettle(tx: TransactionWithCategory) {
+    settleMutation.mutate({ id: tx.id, prev: tx.status });
+  }
 
   const bulkCategoryMutation = createMutation(() => ({
     mutationFn: (catId: string) => updateTransactionsCategory(manageableSelectedIds(), catId),
@@ -652,7 +677,7 @@
         type="button"
         role="tab"
         aria-selected={groupFilter === "all"}
-        onclick={() => (groupFilter = "all")}
+        onclick={() => syncListViewUrl("/transactions", $page.url.searchParams, { group: "all" })}
         class={cn(
           "focus-visible:ring-accent rounded-full px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none",
           groupFilter === "all"
@@ -666,7 +691,7 @@
         type="button"
         role="tab"
         aria-selected={groupFilter === "own"}
-        onclick={() => (groupFilter = "own")}
+        onclick={() => syncListViewUrl("/transactions", $page.url.searchParams, { group: "own" })}
         class={cn(
           "focus-visible:ring-accent rounded-full px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none",
           groupFilter === "own"
@@ -681,7 +706,7 @@
           type="button"
           role="tab"
           aria-selected={groupFilter === g.id}
-          onclick={() => (groupFilter = g.id)}
+          onclick={() => syncListViewUrl("/transactions", $page.url.searchParams, { group: g.id })}
           class={cn(
             "focus-visible:ring-accent rounded-full px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none",
             groupFilter === g.id
@@ -742,6 +767,7 @@
       bind:selectedIds
       stickyHeaderTop={`calc(3.5rem + ${stickyFiltersHeight}px)`}
       onrowclick={(tx) => (sheetTx = tx)}
+      onsettle={quickSettle}
       ondelete={(id: string) => (deleteTargetId = id)}
     />
     {#if renderedTxCount < visibleTxs.length}

--- a/apps/web-svelte/static/sw.js
+++ b/apps/web-svelte/static/sw.js
@@ -1,8 +1,12 @@
-const CACHE_NAME = 'portfelik-20260606';
+const CACHE_NAME = 'portfelik-20260608';
 
 const APP_SHELL = ['/', '/transactions', '/import', '/plans', '/settings'];
 
 const DEFAULT_ICON = '/icon-192x192.png';
+
+/** Must match notification-sync.ts */
+const NOTIFICATION_SYNC_CHANNEL = 'portfelik-notifications';
+const SW_NOTIFICATION_MESSAGE_TYPE = 'portfelik:notification';
 
 self.addEventListener('install', (event) => {
 	event.waitUntil(
@@ -34,22 +38,68 @@ self.addEventListener('fetch', (event) => {
 	);
 });
 
+async function hasVisibleClient() {
+	const windowClients = await clients.matchAll({ type: 'window', includeUncontrolled: true });
+	return windowClients.some((client) => client.visibilityState === 'visible');
+}
+
+function broadcastInvalidate() {
+	try {
+		const channel = new BroadcastChannel(NOTIFICATION_SYNC_CHANNEL);
+		channel.postMessage({ type: 'invalidate' });
+		channel.close();
+	} catch {
+		// BroadcastChannel unavailable in some SW contexts — postMessage still runs.
+	}
+}
+
+function notifyOpenClients(payload) {
+	return clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+		for (const client of windowClients) {
+			client.postMessage({
+				type: SW_NOTIFICATION_MESSAGE_TYPE,
+				payload: {
+					title: payload.title,
+					body: payload.body,
+					notificationId: payload.notificationId
+				}
+			});
+		}
+	});
+}
+
 self.addEventListener('push', (event) => {
-	let payload = { title: 'Portfelik', body: '' };
+	let payload = { title: 'Portfelik', body: '', data: {} };
 	try {
 		payload = event.data?.json() ?? payload;
 	} catch {
 		payload.body = event.data?.text() ?? '';
 	}
 
+	const data = payload.data ?? {};
+	const notificationId = data.notificationId ?? data.type ?? 'portfelik';
+
 	event.waitUntil(
-		self.registration.showNotification(payload.title, {
-			body: payload.body,
-			icon: DEFAULT_ICON,
-			badge: DEFAULT_ICON,
-			vibrate: [100, 50, 100],
-			data: payload.data ?? {},
-			actions: [{ action: 'open', title: 'Otwórz' }]
+		hasVisibleClient().then((visible) => {
+			if (visible) {
+				broadcastInvalidate();
+				return notifyOpenClients({
+					title: payload.title,
+					body: payload.body,
+					notificationId
+				});
+			}
+
+			return self.registration.showNotification(payload.title, {
+				body: payload.body,
+				icon: DEFAULT_ICON,
+				badge: DEFAULT_ICON,
+				tag: notificationId,
+				renotify: false,
+				vibrate: [100, 50, 100],
+				data,
+				actions: [{ action: 'open', title: 'Otwórz' }]
+			});
 		})
 	);
 });

--- a/apps/web-svelte/tests/unit/can-manage-transaction.spec.ts
+++ b/apps/web-svelte/tests/unit/can-manage-transaction.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { canManageTransaction } from "$lib/services/transaction-permissions";
+import {
+  canManageTransaction,
+  isQuickSettleEligible,
+} from "$lib/services/transaction-permissions";
 import type { GroupMemberRole } from "$lib/types";
 
 describe("canManageTransaction", () => {
@@ -23,5 +26,17 @@ describe("canManageTransaction", () => {
   it("allows group owner role on shared row", () => {
     const ownerRoles = new Map<string, GroupMemberRole>([["g3", "owner"]]);
     expect(canManageTransaction({ user_id: "u2", group_id: "g3" }, "u1", ownerRoles)).toBe(true);
+  });
+});
+
+describe("isQuickSettleEligible", () => {
+  it("is eligible for upcoming and overdue", () => {
+    expect(isQuickSettleEligible("upcoming")).toBe(true);
+    expect(isQuickSettleEligible("overdue")).toBe(true);
+  });
+
+  it("is not eligible for already-paid or draft rows", () => {
+    expect(isQuickSettleEligible("paid")).toBe(false);
+    expect(isQuickSettleEligible("draft")).toBe(false);
   });
 });

--- a/apps/web-svelte/tests/unit/financial-snapshots.spec.ts
+++ b/apps/web-svelte/tests/unit/financial-snapshots.spec.ts
@@ -66,18 +66,18 @@ const debtTerms = (overrides: Partial<PlanDebtTerms> = {}): PlanDebtTerms => ({
 });
 
 describe("debtBalanceForNetWorth", () => {
-  it("counts full original for upcoming loans", () => {
+  it("excludes upcoming loans from net worth", () => {
     const balance = debtBalanceForNetWorth(
       debtPlan({ start_date: "2026-07-01" }),
       debtTerms({ original_amount: 200_000, current_balance: 199_000 }),
       "2026-06-08"
     );
-    expect(balance).toBe(200_000);
+    expect(balance).toBe(0);
   });
 
-  it("falls back to plan target when terms row is missing", () => {
+  it("falls back to plan target when active plan has no terms row", () => {
     const balance = debtBalanceForNetWorth(
-      debtPlan({ target_amount: 150_000, start_date: "2026-08-01" }),
+      debtPlan({ target_amount: 150_000, start_date: "2025-01-01", end_date: "2045-01-01" }),
       undefined,
       "2026-06-08"
     );
@@ -95,7 +95,7 @@ describe("debtBalanceForNetWorth", () => {
 });
 
 describe("collectNetWorthDebtBalances", () => {
-  it("sums active and upcoming debt plans", () => {
+  it("sums active debt plans only", () => {
     const plans = [
       debtPlan({ id: "d1", start_date: "2025-01-01", end_date: "2030-01-01" }),
       debtPlan({
@@ -115,7 +115,7 @@ describe("collectNetWorthDebtBalances", () => {
       d2: debtTerms({ plan_id: "d2", original_amount: 100_000, current_balance: 100_000 }),
     };
     const balances = collectNetWorthDebtBalances(plans, terms, "2026-06-08");
-    expect(balances).toHaveLength(2);
-    expect(balances.reduce((a, b) => a + b, 0)).toBe(307_000);
+    expect(balances).toHaveLength(1);
+    expect(balances[0]).toBe(207_000);
   });
 });

--- a/apps/web-svelte/tests/unit/financial-surplus.spec.ts
+++ b/apps/web-svelte/tests/unit/financial-surplus.spec.ts
@@ -51,6 +51,58 @@ describe("computeMonthlySurplus", () => {
     expect(result.surplus).toBe(200);
     expect(result.afterSaveGoals).toBe(-300);
   });
+
+  it("flags the debt assumption unverified when coverage is not supplied", () => {
+    const result = computeMonthlySurplus({
+      totalIncome: 5000,
+      totalExpenses: 4800,
+      debtMonthlyPayments: 2370,
+      saveMonthlyNeeded: 0,
+    });
+    expect(result.debtAssumptionVerified).toBe(false);
+    expect(result.unreflectedDebt).toBe(0);
+    // unchanged math: full payment assumed already inside expenses
+    expect(result.afterSaveGoals).toBe(200);
+  });
+
+  it("subtracts the unreflected debt shortfall when coverage is partial", () => {
+    const result = computeMonthlySurplus({
+      totalIncome: 5000,
+      totalExpenses: 4800,
+      debtMonthlyPayments: 2370,
+      debtPaymentsInExpenses: 1370,
+      saveMonthlyNeeded: 0,
+    });
+    expect(result.debtAssumptionVerified).toBe(true);
+    expect(result.unreflectedDebt).toBe(1000);
+    // cashflow 200 − save 0 − unreflected 1000
+    expect(result.afterSaveGoals).toBe(-800);
+  });
+
+  it("does not double-count when debt payments are fully reflected in expenses", () => {
+    const result = computeMonthlySurplus({
+      totalIncome: 12000,
+      totalExpenses: 8500,
+      debtMonthlyPayments: 2370,
+      debtPaymentsInExpenses: 2370,
+      saveMonthlyNeeded: 800,
+    });
+    expect(result.debtAssumptionVerified).toBe(true);
+    expect(result.unreflectedDebt).toBe(0);
+    expect(result.afterSaveGoals).toBe(2700);
+  });
+
+  it("clamps unreflected debt at zero when expenses over-report the payment", () => {
+    const result = computeMonthlySurplus({
+      totalIncome: 5000,
+      totalExpenses: 4800,
+      debtMonthlyPayments: 2370,
+      debtPaymentsInExpenses: 3000,
+      saveMonthlyNeeded: 0,
+    });
+    expect(result.unreflectedDebt).toBe(0);
+    expect(result.afterSaveGoals).toBe(200);
+  });
 });
 
 describe("sumDebtMonthlyPayments", () => {

--- a/apps/web-svelte/tests/unit/notification-sync.spec.ts
+++ b/apps/web-svelte/tests/unit/notification-sync.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import type { QueryClient } from "@tanstack/svelte-query";
+import {
+  broadcastNotificationSync,
+  notifyNotificationsChanged,
+  NOTIFICATION_SYNC_CHANNEL,
+} from "$lib/services/notification-sync";
+
+describe("notification-sync", () => {
+  it("broadcastNotificationSync is a no-op without BroadcastChannel", () => {
+    expect(() => broadcastNotificationSync({ type: "invalidate" })).not.toThrow();
+  });
+
+  it("notifyNotificationsChanged invalidates the notifications query", () => {
+    const invalidateQueries = vi.fn();
+    const queryClient = { invalidateQueries } as unknown as QueryClient;
+
+    notifyNotificationsChanged(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["notifications"] });
+  });
+
+  it("exports a stable channel name for sw.js parity", () => {
+    expect(NOTIFICATION_SYNC_CHANNEL).toBe("portfelik-notifications");
+  });
+});

--- a/apps/web-svelte/tests/unit/plan-debt.spec.ts
+++ b/apps/web-svelte/tests/unit/plan-debt.spec.ts
@@ -74,6 +74,43 @@ describe("consolidateDebtLinkedPayments", () => {
       ])
     ).toEqual([2370, 2370]);
   });
+
+  it("still groups dated rows by month when some rows are undated", () => {
+    expect(
+      consolidateDebtLinkedPayments([
+        { amount: 1000, date: "2026-01-05" },
+        { amount: 1370, date: "2026-01-20" },
+        { amount: 2370, date: "2026-02-10" },
+        { amount: 500 },
+      ])
+    ).toEqual([2370, 2370, 500]);
+  });
+
+  it("appends undated periods after dated months", () => {
+    expect(
+      consolidateDebtLinkedPayments([
+        { amount: 800 },
+        { amount: 1000, date: "2026-03-01" },
+      ])
+    ).toEqual([1000, 800]);
+  });
+
+  it("is deterministic regardless of input order", () => {
+    const a = consolidateDebtLinkedPayments([
+      { amount: 2370, date: "2026-02-10" },
+      { amount: 500 },
+      { amount: 1370, date: "2026-01-20" },
+      { amount: 1000, date: "2026-01-05" },
+    ]);
+    const b = consolidateDebtLinkedPayments([
+      { amount: 1000, date: "2026-01-05" },
+      { amount: 2370, date: "2026-02-10" },
+      { amount: 1370, date: "2026-01-20" },
+      { amount: 500 },
+    ]);
+    expect(a).toEqual([2370, 2370, 500]);
+    expect(a).toEqual(b);
+  });
 });
 
 describe("deriveDebtBalanceFromLinks", () => {

--- a/apps/web-svelte/tests/unit/plan-settlement.spec.ts
+++ b/apps/web-svelte/tests/unit/plan-settlement.spec.ts
@@ -5,6 +5,7 @@ vi.mock("$lib/supabase", () => ({ supabase: {} }));
 import {
   computePlanProgress,
   computeSaveMonthlyActual,
+  computeSaveMonthlyActualDetail,
   rankPlanTransaction,
 } from "$lib/services/plan-settlement";
 import type { TransactionWithCategory } from "$lib/types";
@@ -132,6 +133,69 @@ describe("computeSaveMonthlyActual", () => {
   });
 });
 
+describe("computeSaveMonthlyActualDetail", () => {
+  it("reports a current-month basis when there is a deposit this month", () => {
+    const detail = computeSaveMonthlyActualDetail({
+      kind: "save",
+      startDate: "2026-01-01",
+      savedAmount: 12_000,
+      linkedIncomes: [
+        tx({ type: "income", amount: 500, date: "2026-06-08" }),
+        tx({ type: "income", amount: 300, date: "2026-01-15" }),
+      ],
+      today: "2026-06-08",
+    });
+    expect(detail.amount).toBe(500);
+    expect(detail.basis).toBe("current-month");
+  });
+
+  it("flags the elapsed-average fallback as a historical estimate", () => {
+    const detail = computeSaveMonthlyActualDetail({
+      kind: "save",
+      startDate: "2026-01-01",
+      savedAmount: 6000,
+      linkedIncomes: [tx({ type: "income", amount: 6000, date: "2026-03-10" })],
+      today: "2026-04-10",
+    });
+    expect(detail.amount).toBe(2000);
+    expect(detail.basis).toBe("historical-average");
+  });
+
+  it("reports no basis when nothing has been saved yet", () => {
+    const detail = computeSaveMonthlyActualDetail({
+      kind: "save",
+      startDate: "2026-01-01",
+      savedAmount: 0,
+      linkedIncomes: [],
+      today: "2026-06-08",
+    });
+    expect(detail.amount).toBe(0);
+    expect(detail.basis).toBe("none");
+  });
+
+  it("returns a null amount and no basis for non-save plans", () => {
+    const detail = computeSaveMonthlyActualDetail({
+      kind: "spend",
+      savedAmount: 1000,
+      linkedIncomes: [],
+      today: "2026-06-08",
+    });
+    expect(detail.amount).toBeNull();
+    expect(detail.basis).toBe("none");
+  });
+
+  it("matches computeSaveMonthlyActual for the same input", () => {
+    const args = {
+      kind: "save" as const,
+      startDate: "2026-01-01",
+      savedAmount: 6000,
+      linkedIncomes: [tx({ type: "income", amount: 6000, date: "2026-03-10" })],
+      today: "2026-04-10",
+    };
+    expect(computeSaveMonthlyActualDetail(args).amount).toBe(computeSaveMonthlyActual(args));
+  });
+});
+
 describe("computePlanProgress", () => {
   it("computes save goal monthly needed and actual from linked income", () => {
     const end = new Date();
@@ -176,5 +240,43 @@ describe("computePlanProgress", () => {
     });
 
     expect(progress.monthlyNeeded).toBeGreaterThan(progress.monthlyActual ?? 0);
+  });
+});
+
+describe("computePlanProgress linkedExpenseCurrentMonth", () => {
+  it("sums current-month paid linked expenses (debt payment coverage)", () => {
+    const progress = computePlanProgress({
+      planId: "debt-1",
+      planName: "Kredyt",
+      kind: "debt",
+      budgetAmount: null,
+      targetAmount: null,
+      startDate: "2026-01-01",
+      endDate: "2030-01-01",
+      linkedTransactions: [
+        tx({ id: "a", type: "expense", amount: 2370, date: "2026-06-05", status: "paid" }),
+        tx({ id: "b", type: "expense", amount: 2370, date: "2026-05-05", status: "paid" }),
+      ],
+      today: "2026-06-08",
+    });
+    expect(progress.linkedExpenseCurrentMonth).toBe(2370);
+  });
+
+  it("excludes non-current-month and non-paid linked expenses", () => {
+    const progress = computePlanProgress({
+      planId: "debt-1",
+      planName: "Kredyt",
+      kind: "debt",
+      budgetAmount: null,
+      targetAmount: null,
+      startDate: "2026-01-01",
+      endDate: "2030-01-01",
+      linkedTransactions: [
+        tx({ id: "a", type: "expense", amount: 2370, date: "2026-06-05", status: "upcoming" }),
+        tx({ id: "b", type: "expense", amount: 1000, date: "2026-04-05", status: "paid" }),
+      ],
+      today: "2026-06-08",
+    });
+    expect(progress.linkedExpenseCurrentMonth).toBe(0);
   });
 });

--- a/apps/web-svelte/tests/unit/planning-queue.spec.ts
+++ b/apps/web-svelte/tests/unit/planning-queue.spec.ts
@@ -184,3 +184,55 @@ describe("buildPlanningQueueActions", () => {
     expect(actions.length).toBeLessThanOrEqual(3);
   });
 });
+
+describe("buildPlanningQueueActions save-pace basis", () => {
+  const surplus = {
+    totalIncome: 8000,
+    totalExpenses: 5000,
+    cashflowNet: 3000,
+    debtMonthlyPayments: 0,
+    saveMonthlyNeeded: 1000,
+    surplus: 3000,
+    afterSaveGoals: 2000,
+    unreflectedDebt: 0,
+    debtAssumptionVerified: false,
+    hasSaveGoals: true,
+    hasDebtPlans: false,
+  };
+
+  it("still warns when pace meets need only via historical average", () => {
+    const actions = buildPlanningQueueActions({
+      summaries: [
+        summary({
+          id: "save-1",
+          kind: "save",
+          target_amount: 60_000,
+          monthlyNeeded: 1000,
+          monthlyActual: 1500,
+          monthlyActualBasis: "historical-average",
+        }),
+      ],
+      monthlySurplus: surplus,
+      debtTerms: {},
+    });
+    expect(actions.some((a) => a.id === "save-save-1")).toBe(true);
+  });
+
+  it("does not warn when current-month deposits meet the need", () => {
+    const actions = buildPlanningQueueActions({
+      summaries: [
+        summary({
+          id: "save-1",
+          kind: "save",
+          target_amount: 60_000,
+          monthlyNeeded: 1000,
+          monthlyActual: 1500,
+          monthlyActualBasis: "current-month",
+        }),
+      ],
+      monthlySurplus: surplus,
+      debtTerms: {},
+    });
+    expect(actions.some((a) => a.id === "save-save-1")).toBe(false);
+  });
+});

--- a/apps/web-svelte/tests/unit/plans.spec.ts
+++ b/apps/web-svelte/tests/unit/plans.spec.ts
@@ -6,6 +6,8 @@ import {
   addCalendarMonths,
   calendarMonthsUntil,
   derivePlanBucket,
+  savePlanDeadlineAnchor,
+  savePlanSliderMonths,
   todayIso,
 } from "$lib/services/plans";
 import type { Plan } from "$lib/types";
@@ -61,5 +63,30 @@ describe("calendar month helpers", () => {
     const at13 = addCalendarMonths(todayIso(), 13);
     expect(calendarMonthsUntil(at13)).toBe(13);
     expect(at13 < at14).toBe(true);
+  });
+});
+
+describe("save plan deadline slider", () => {
+  it("anchors upcoming goals at start_date", () => {
+    const upcoming = plan({
+      kind: "save",
+      start_date: "2027-01-04",
+      end_date: "2027-07-08",
+      target_amount: 40_000,
+    });
+    expect(savePlanDeadlineAnchor(upcoming, "2026-06-08")).toBe("2027-01-04");
+    expect(savePlanSliderMonths(upcoming, "2026-06-08")).toBe(6);
+    expect(addCalendarMonths("2027-01-04", 3)).toBe("2027-04-04");
+  });
+
+  it("anchors active goals at today", () => {
+    const active = plan({
+      kind: "save",
+      start_date: "2026-01-01",
+      end_date: "2027-01-01",
+      target_amount: 40_000,
+    });
+    expect(savePlanDeadlineAnchor(active, "2026-06-08")).toBe("2026-06-08");
+    expect(savePlanSliderMonths(active, "2026-06-08")).toBe(6);
   });
 });

--- a/docs/PRODUCT_REVIEW_2026-06-09.md
+++ b/docs/PRODUCT_REVIEW_2026-06-09.md
@@ -1,0 +1,181 @@
+# Portfelik — Product Review
+
+**Date:** 2026-06-09
+**Trigger:** User-requested deep pass on the Plans feature + Dashboard/Transactions/Settings for inconsistencies, calculation-logic gaps, UX/intent alignment, and core-loop coherence.
+**Prior review:** `docs/PRODUCT_REVIEW_2026-06-07.md` (pre-launch readiness pass)
+
+---
+
+## Executive Summary
+
+The app is in strong shape post-launch-freeze: the import→organize→intent→settle→condition loop exists end-to-end, the settlement surface is genuinely intent-oriented (ranked suggestions with human-readable reasons), and test coverage is broad (60+ vitest specs, 8 Playwright suites, full RLS matrix). Biggest strength: **the settlement flow is the best embodiment of the north star** — it links reality to intent instead of forcing manual truth. Most urgent gap: the **save-pace and debt-balance calculations rest on coarse heuristics that can silently mislabel a plan as "on track"** and the **surplus formula trusts an unverified assumption that debt payments already live inside tracked expenses** — both quietly corrupt the one number users will trust most. Recommended next action: tighten the three financial heuristics (save pace, debt consolidation order, surplus double-count guard) and add an explanation/uncertainty marker where the number is an estimate, before inviting beta couples.
+
+---
+
+## Closed since last review (2026-06-07)
+
+The prior review's urgent gaps were operational and have largely closed per `CLAUDE.md`:
+
+- Production-readiness stack (tx co-owner migration, export test, doc syncs) committed/pushed and promoted `dev`→`main` (2026-06-07/08).
+- Launch certification 2026-06-08: gates green, manual prod/staging verification done, feature freeze in effect.
+- Trust hardening landed (#111/#112): ledger-vs-forecast cashflow, plan settlement policy, shared-tx write gates.
+- Group plans G2 (co-owner write gates) and Net worth D2 (surplus card, Pulpit strip) shipped.
+
+**Still open from 06-07:** leaked-password protection toggle (prod+staging, operator), `pg_net` in `public` schema (re-enable via Dashboard on cloud).
+
+---
+
+## A. Feature Completeness  `8/10`
+
+Plans ships three kinds (spend/save/debt) with first-class storage, settlement, debt amortization, Belka overpay-vs-invest scenarios, surplus card, and net-worth strip. All product-spine routes (Pulpit, Transakcje, Import, Plany, Ustawienia) are reachable from `Navigation.svelte` on mobile and desktop. Legacy `/shopping-lists` routes are clean 301 redirects to `/plans` — no orphans. Settlement, scenarios, and per-kind detail screens all exist.
+
+**Gaps:**
+- **Plans nav icon is still `ShoppingBasket`** (`Navigation.svelte:32,38`) — a shopping-list metaphor that no longer matches spend/save/debt intent. Visual lie about what the section is.
+- **Dashboard upcoming transactions are passive** — read-only cards, no inline "mark paid"/quick-settle; the user must navigate to a filtered `/transactions` view to act, breaking the settle loop at its most natural trigger point.
+- **No inline single-tap settle from a transactions row** — single-item settlement is hidden behind the detail sheet; bulk status change is multi-step (select → action bar).
+- Offline write queue (Dexie outbox) still a known parity gap vs legacy `FirestoreService` (backlog, deferred).
+
+---
+
+## B. Test Coverage  `8/10`
+
+Strong. Every financial service has a unit spec (`plan-debt`, `financial-surplus`, `planning-queue`, `plan-settlement`, `plan-settlement-policy`, `debt-amortization`, `dashboard-daily`, `transaction-cashflow`). Full RLS regression matrix incl. `plans`, `plan_debt_terms`, `plan_settlement`, group co-owner roles. Playwright covers plans, plan-settle, group-roles, bank-import, a11y spine.
+
+**Gaps:**
+- The **heuristic branches** are the risk, not the happy path: `computeSaveMonthlyActual` lump-sum-vs-recurring fallback and `consolidateDebtLinkedPayments` mixed dated/undated path need explicit unit cases that assert the *misleading* outcome is handled.
+- No Playwright spec exercises the **save-plan "on track" badge** flipping with deposit timing, nor the **surplus headline** switching meaning when save goals exist.
+- Dashboard drill-down / quick-settle has no E2E (because the affordance doesn't exist yet).
+
+---
+
+## C. Development Workflow  `8/10`
+
+Branch-sync discipline is documented and visible in recent history (dev synced from main, e2e mock anchored to today). Conventional commits, migration-per-concern discipline, gates defined. CI present.
+
+**Gaps:**
+- `apps/web-svelte/CLAUDE.md` "Immediate next step" handoff is **stale at the app level** (see H) — a cold-starting agent would be misled about how Plans is stored.
+- Did not verify CI runs `format:check` / secret-scan in this pass (user-directed focus was product/UX); the prior 06-07 review confirmed both gates exist.
+
+---
+
+## D. Security  `8/10`
+
+Group writes go through SECURITY DEFINER RPCs; RLS matrix is comprehensive incl. `function_execute_hardening` and `max_user_cap`. Co-owner plan/debt write gates tested. No secret-leak signal in changed plan files.
+
+**Gaps:**
+- SECURITY DEFINER `search_path`-pin audit not re-run this pass (product-focused); 06-07 flagged 3 unpinned privacy functions — confirm closed before beta.
+- Leaked-password advisor toggle (prod+staging) still operator-pending.
+
+---
+
+## E. Backend Patterns & Database  `7/10`
+
+Money handled as numeric, balances rounded to cents (`Math.round(balance*100)/100`). Amortization stop-conditions guard negative amortization (`payment <= interest + 0.01`). Settlement scoring is deterministic and explainable.
+
+**Calculation gaps (the core of this review):**
+- **Surplus double-count assumption (`financial-surplus.ts`).** `computeMonthlySurplus` comments "Raty kredytów nie odejmujemy ponownie — są już w wydatkach," but performs **no check** that debt payments are actually inside `totalExpenses`. If a user pays a loan from an untracked account, or only links it as a plan, `afterSaveGoals` over-reports free capacity — the single most-trusted number is silently wrong. Add a reconciliation guard or surface the assumption.
+- **Save-pace heuristic (`plan-settlement.ts` `computeSaveMonthlyActual`).** Fallback divides `savedAmount / elapsedMonths`. A lump-sum upfront deposit inflates the implied monthly pace → plan wrongly marked "on track" → `planning-queue` suppresses the save suggestion → user under-saves while the UI says they're fine. Distinguish recurring deposits from one-off, or label the figure as an estimate.
+- **Debt consolidation order (`plan-debt.ts` `consolidateDebtLinkedPayments`).** When linked payments mix dated and undated rows, code falls back to an ungrouped `sorted.map(e => e.amount)` path, abandoning monthly grouping. Amortization applied as several small payments vs one grouped payment yields a different derived balance. Make the mixed case deterministic.
+- **Compounding mismatch (`debt-amortization.ts`).** Period amortization compounds monthly; `accrueBalanceWithDailyInterest` compounds daily `(1+dailyRate)^days`. Most PL mortgages/loans compound monthly — daily accrual slightly inflates interest between payment dates. Acceptable for display, but document it as an estimate so the two paths don't disagree visibly.
+- **Queue picks only the first off-track save/debt plan** (`planning-queue.ts`) — a plan off by 1% can outrank one off by 99% depending on `monthlyNeeded` sort. Rank by shortfall severity, not just magnitude.
+
+**DB note (verified consistent):** net-worth liability excludes upcoming debt plans (product call; the brief `c39814b` inclusion was reverted), and surplus/queue use active-only buckets — so majątek netto and surplus tell a consistent story. No action.
+
+---
+
+## F. Frontend Patterns & Svelte  `7/10`
+
+Svelte 5 runes throughout, design tokens (oklch, accent-gradient, tabular-nums), UI primitives reused, loading skeletons + multi-variant empty states on Transactions, casual Polish copy that is genuinely warm ("Pasuje świetnie", "Nie widzisz tu swojego wydatku? Dodaj ręcznie"). Settlement reasons are exemplary explanation-layer UX.
+
+**Inconsistency gaps:**
+- **PlanCard progress is asymmetric across kinds** (`PlanCard.svelte`). Save shows `savePct` (clamped `min(100)`), spend shows `spentPct` (amber at ≥90%), but **debt shows monthly payment on the right rail instead of a percentage**, and `debtPaidPct` is **not clamped to 100** (save is). Three kinds, three different right-rail semantics — harder to scan a mixed list.
+- **SurplusCard headline silently changes meaning** (`SurplusCard.svelte:15`): shows `afterSaveGoals` when `hasSaveGoals`, else `surplus`. Same prominent number means "free cash" or "free cash after goals" with only a copy-string difference — a trust risk on the headline figure.
+- **Group-filter state is inconsistent across screens**: Dashboard uses URL params, Transactions uses local state → group context is lost when navigating between them.
+- **Permission blindness**: `canManageTransaction` silently hides edit/delete with no "why" — violates the doctrine's explanation layer ("explain at trust moments").
+- Dashboard has **no visible error state** (relies on TanStack defaults) while Transactions has an explicit one — inconsistent failure UX.
+
+---
+
+## G. Architecture & Structure  `8/10`
+
+Clean layering: route page → service → Supabase. Plan logic is well-decomposed into single-purpose services (`plans`, `plan-debt`, `financial-surplus`, `planning-queue`, `plan-settlement`, `plan-settlement-policy`, `debt-amortization`). Static-adapter constraint respected (redirects via `+page.ts` load, no `+server.ts`).
+
+**Gaps:**
+- `plans/+page.svelte` is **999 lines** and `plans/[id]/+page.svelte` is **626** — the create/edit form + kind picker + query orchestration are concentrated in the route file. Extracting a `PlanForm` component (the form is currently inline) would cut size and let the kind picker be tested in isolation.
+- Surplus/net-worth condition logic is split across `/plans` (SurplusCard) and `/dashboard` (NetWorthStrip, PlanProgress) — two homes for "financial condition," risk of divergence.
+
+---
+
+## H. Documentation  `6/10`
+
+Root `CLAUDE.md` phase table and product spine are current and detailed. Product-direction + intent-oriented-ui docs are excellent and genuinely usable as a review rubric.
+
+**Gaps (doc rot — highest in this dimension):**
+- **`apps/web-svelte/CLAUDE.md` is stale and actively misleading.** It still lists `shopping-lists.ts` as "current internal service for user-facing Plans," references `complete_shopping_list` RPC and `ShoppingList*` types as the Plans backbone. The code has moved to first-class `plans.ts` / `plan-debt.ts` / `plan-settlement.ts`. The svelte-gotchas file's gotcha #4 (`complete_shopping_list` returns a transactions row) is also obsolete. A cold-starting agent would build against the wrong storage model.
+- `docs/architecture/database.md` currency with `plans`, `plan_debt_terms`, `plan_transaction_links` not verified this pass — check it reflects the first-class Plans schema.
+- *(Process note: this review's own file was nearly lost to a stale sandbox-overlay write; verify generated docs land on real disk.)*
+
+---
+
+## I. Roadmap & North Star  `8/10`
+
+North star = spending visibility + shared household expenses, mobile-first, minimal friction. The backlog serves it. Settlement is the strongest north-star artifact in the app: deterministic engine + intent memory + explanation layer + user-decides-exceptions, exactly per doctrine. The debt **scenarios** screen (Belka overpay-vs-invest, daily accrual) is the one place where complexity may outrun the *typical* target user — but for mortgage-holding couples it is a genuine differentiator. Keep it; just don't polish it before the basic surplus number is honest.
+
+**Priority order:** (1) make the trusted numbers honest (surplus guard, save pace, debt consolidation), (2) close the settle loop at the trigger points (dashboard/transactions quick-settle), (3) fix cross-screen inconsistencies (nav icon, group-filter state, progress semantics), (4) then resume advanced scenario polish.
+
+**Highest-impact next feature:** inline quick-settle from Dashboard upcoming + Transactions row — it closes the loop at the exact moment the user sees reality meet intent, which is the whole product thesis.
+
+---
+
+## Scorecard
+
+| Dimension              | Score | Key finding |
+|------------------------|-------|-------------|
+| Feature completeness   | 8/10  | Loop complete; settle not triggerable where intent appears (dashboard/tx row) |
+| Test coverage          | 8/10  | Broad; heuristic branches under-tested for the *misleading* case |
+| Dev workflow           | 8/10  | Disciplined; app-level handoff doc stale |
+| Security               | 8/10  | RLS strong; search_path + advisor re-check pending |
+| Backend patterns       | 7/10  | Surplus double-count assumption + save-pace + debt-consolidation heuristics can silently mislead |
+| Frontend patterns      | 7/10  | Per-kind progress semantics inconsistent; surplus headline meaning shifts |
+| Architecture           | 8/10  | Clean layering; 999-line plans route + split condition logic |
+| Documentation          | 6/10  | `apps/web-svelte/CLAUDE.md` describes retired shopping-list storage as current |
+| North star alignment   | 8/10  | Settlement is exemplary; scenarios risk outrunning typical user |
+| **Overall**            | **7.6/10** | Healthy, near-launch; tighten the numbers users trust before beta |
+
+---
+
+## Action Checklist
+
+### Must close before any new feature
+- [x] **Surplus double-count guard** — in `financial-surplus.ts` `computeMonthlySurplus`, either verify debt payments are inside `totalExpenses` or stop assuming it; surface "estimate" when unverifiable. This number drives every condition surface.
+- [x] **Save-pace honesty** — `plan-settlement.ts` `computeSaveMonthlyActual`: stop letting a lump-sum inflate the monthly pace into a false "on track" badge; distinguish recurring vs one-off, or label as estimate.
+- [x] **Debt consolidation determinism** — `plan-debt.ts` `consolidateDebtLinkedPayments`: define one deterministic order for the mixed dated/undated case; add a unit test asserting the derived balance.
+- [x] **Fix `apps/web-svelte/CLAUDE.md`** — replace shopping-list service/RPC/type references with the first-class Plans model (`plans.ts`, `plan-debt.ts`, `plan-settlement.ts`); remove obsolete gotcha #4.
+
+### High value, low overengineering risk
+- [x] Inline quick-settle from Dashboard upcoming + a single-tap settle on Transactions rows (closes the loop at the intent moment).
+- [x] Swap Plans nav icon off `ShoppingBasket` to a target/goal metaphor (`Navigation.svelte:32,38`).
+- [x] Unify group-filter state (URL param) across Dashboard and Transactions so context survives navigation.
+- [x] Make PlanCard right-rail semantics consistent across spend/save/debt; clamp `debtPaidPct` to 100.
+
+### Medium term
+- [ ] Extract `PlanForm` out of the 999-line `plans/+page.svelte`; test the kind picker in isolation.
+- [ ] Add an explanation/disabled-state for permission-gated transaction edit (doctrine: explain at trust moments).
+- [ ] Add Dashboard error state to match Transactions.
+- [ ] Document daily-vs-monthly compounding as display-estimate in `debt-amortization.ts`.
+- [ ] Rank planning-queue by shortfall severity, not first-plan magnitude.
+
+### Consciously deferred (and why)
+- Offline write queue (Dexie outbox) — last-write-wins decided, no current UX failure; safe to defer.
+- Auto net-worth from import — manual snapshot ships value now; automation is polish.
+- Belka invest-vs-overpay scenario polish — already shipped; defer further depth until the basic trusted numbers are hardened (avoid overengineering ahead of trust).
+
+---
+
+## Update 2026-06-09 (implementation)
+
+All four must-close items closed and committed; surplus now wires real `debtPaymentsInExpenses` from current-month linked debt expenses on `/plans` (verified math when progress loads, estimate marker until then). planning-queue now treats `historical-average` save pace as no current-month pace so a lump sum no longer suppresses the warn chip. Quick-settle shipped on Dashboard upcoming + Transactions rows (mark-paid, optimistic, undo toast, permission-gated) with a Playwright case. Gates: svelte-check 0/0, eslint 0 errors, unit 160 passed, e2e transactions 15 passed.
+
+---
+
+*Generated by `/reflect` on 2026-06-09. Update CLAUDE.md "Immediate next step" after closing must-close items.*

--- a/docs/architecture/flows/notifications-push.md
+++ b/docs/architecture/flows/notifications-push.md
@@ -138,4 +138,19 @@ Notifications could be pushed to live tabs via Supabase Realtime without web-pus
 
 ## In-app bell
 
-The in-app notification list is read straight from `public.notifications` via TanStack Query (`["notifications"]`, 5-min staleTime + `refetchOnReconnect`). `mark_notification_read(id)` and `mark_all_notifications_read()` RPCs flip `read_at`. There is no Realtime subscription; the bell becomes accurate on the next refetch (most commonly when the user clicks something or comes back online).
+The in-app notification list is read straight from `public.notifications` via TanStack Query (`["notifications"]`, 30s staleTime in the popover + `refetchOnReconnect`). `mark_notification_read(id)` and `mark_all_notifications_read()` RPCs flip `read_at`. There is no Realtime subscription; the bell becomes accurate on the next refetch (most commonly when the user clicks something or comes back online).
+
+## Foreground + cross-tab sync (native-like)
+
+`static/sw.js` push handler:
+
+1. If any Portfelik tab is **visible** (`WindowClient.visibilityState === 'visible'`):
+   - **Skip** `showNotification` (no OS banner while the app is open).
+   - `postMessage` to all open clients + `BroadcastChannel('portfelik-notifications')` with `{ type: 'invalidate' }`.
+   - The focused tab may show a subtle in-app toast (`+layout.svelte`); the bell refetches everywhere.
+2. If all tabs are hidden/closed:
+   - `showNotification` with `tag: notificationId` so duplicate sends replace rather than stack.
+
+`notification-sync.ts` wires SW messages and `BroadcastChannel` into TanStack Query invalidation. Mark-read/delete mutations call `notifyNotificationsChanged()` so other tabs pick up `read_at` without waiting for staleTime.
+
+`Navigation.svelte` mounts a **single** `NotificationsPopover` (desktop or mobile breakpoint, not both).

--- a/docs/product/debt-and-savings-goals.md
+++ b/docs/product/debt-and-savings-goals.md
@@ -46,10 +46,10 @@ raty** / **Spłać / nadpłać** (debt).
 
 - `financial_snapshots`: one row per user - `cash_amount`, `investments_amount`,
   `real_estate_amount`, `as_of_date` (all manual entry).
-- **Majątek netto** on `/plans` = sum(assets) − sum(debt liabilities). Active loans use
-  accrued balance to the snapshot date; **upcoming (future) loans** count full
-  `original_amount`; finished loans drop out when balance is zero. If terms are not
-  saved yet, `plans.target_amount` is used as fallback.
+- **Majątek netto** on `/plans` = sum(assets) − sum(debt liabilities). Only **active**
+  loans count (accrued balance to the snapshot date); upcoming/future loans are
+  excluded until `start_date`; finished loans drop out when balance is zero. If
+  terms are not saved yet on an active plan, `plans.target_amount` is used as fallback.
 - Copy states values are user-entered; Portfelik does not derive bank balances from import.
 - **Pulpit strip (D2):** compact net-worth summary linking to `/plans`; same manual snapshot.
 


### PR DESCRIPTION
* fix(plans): exclude future loans from net worth, fix save deadline slider

* feat(notifications): native-like push foreground and cross-tab sync

* docs: add 2026-06-09 product review and fix Plans doc rot

The Plans review surfaced that apps/web-svelte/CLAUDE.md and svelte-gotchas still described the retired shopping-list storage as the Plans backbone, which would mislead a cold-starting agent into building against the wrong model. Point them at first-class plans.ts / plan-debt.ts / plan-settlement.ts and retire the obsolete complete_shopping_list gotcha. Adds the dated review doc.



* fix(plans): guard surplus against debt not reflected in expenses

computeMonthlySurplus assumed loan raty were always already inside tracked expenses and never verified it, so afterSaveGoals silently over-reported free capacity when a payment was paid from an untracked account. Add optional debtPaymentsInExpenses coverage: any shortfall becomes unreflectedDebt and is subtracted, and debtAssumptionVerified flags when the assumption is unchecked. SurplusCard now shows an estimate marker in that case so the headline number no longer presents an unverified assumption as fact. Adds both new i18n keys.



* fix(plans): distinguish demonstrated vs averaged save pace

The save "on track" badge could be satisfied by an inflated monthly pace derived from a single upfront lump sum averaged over elapsed months, hiding that the user had actually stopped saving. computeSaveMonthlyActualDetail now returns the basis (current-month vs historical-average vs none) alongside the amount, threaded through PlanSummary as monthlyActualBasis, so the UI can stop asserting on-track confidently from a stale historical average.



* fix(plans): deterministic debt consolidation for mixed-dated links

When linked debt payments mixed dated and undated rows, consolidation abandoned month-grouping entirely and made each row its own interest period, so the derived balance depended on input order. Always group dated rows by calendar month and apply undated rows as their own periods afterwards, making the result order-independent.



* fix(plans): PlanCard estimate badge and consistent right-rail

Split the save on-track badge into a confident variant (current-month pace) and an estimate variant (historical average), clamp debtPaidPct to 0-100, and show a percentage on the debt right-rail like save/spend so all three plan kinds scan the same way in a mixed list.



* refactor(nav): swap Plans shopping-basket icon for target

Plans now covers spend/save/debt intent; the leftover ShoppingBasket icon was a shopping-list metaphor that misrepresented the section. Use Target.



* refactor(transactions): drive group filter from URL like dashboard

Transactions kept its group filter in local state while Dashboard drove it from the URL, so group context was lost when navigating between them. Read/write the scope via parseScopeFilter + syncListViewUrl so the filter survives navigation and is shareable.



* chore(plans): drop unused todayIso import in SavePlanDetail

Pre-existing unused import tripping the no-unused-vars lint gate.



* fix(plans): wire real debt coverage into surplus and harden save queue

Completes the surplus must-close: computePlanProgress now exposes linkedExpenseCurrentMonth (paid linked expenses dated this month), and the /plans surplus sums it across active debt plans into debtPaymentsInExpenses, so once progress loads users get verified afterSaveGoals math instead of a blanket estimate. planning-queue now counts only current-month deposits as keeping pace, so a lump-sum-inflated historical average no longer suppresses the off-track warn chip. SavePlanDetail labels an averaged pace as an estimate.



* feat(plans): inline quick-settle on dashboard upcoming and tx rows

Closes the settle loop where intent appears. Upcoming/overdue transactions now carry a "mark paid" action beside their status badge in the shared TransactionTable, gated by isQuickSettleEligible + canManage. Both Dashboard upcoming and the Transactions list wire a mutation that flips status to paid optimistically with a toast Undo, then invalidates the transactions query. Adds an upcoming fixture row and a Playwright case covering the flow.



* docs: tick closed items in 2026-06-09 product review

Mark the four must-close calc/doc items and the high-value UX items done, and record that surplus now wires real debt coverage, the queue is basis-aware, and quick-settle shipped with an e2e case.



* fix(a11y): avoid nested-interactive on quick-settle tx rows

---------

<!--
Prefer the automation: run `scripts/open-pr.sh` (or the `/pr` command) - it runs all
gates and fills this body for you. This stub is only a fallback for hand-opened PRs.
-->

## Summary

-

## Why

-
