### PR TITLE
fix(plans): atomic refinance RPC + dashboard status filter

### DIFF
--- a/apps/web-svelte/e2e/tests/plans.spec.ts
+++ b/apps/web-svelte/e2e/tests/plans.spec.ts
@@ -169,33 +169,17 @@ test("debt plan detail shows balance hero and scenarios link", async ({ page }) 
 });
 
 test("refinances a debt plan: closes old, opens new, writes no transaction", async ({ page }) => {
-  let newPlanBody: Record<string, unknown> | undefined;
-  let oldPatchBody: Record<string, unknown> | undefined;
-  let newTermsBody: Record<string, unknown> | undefined;
+  let rpcBody: Record<string, unknown> | undefined;
   let transactionWritten = false;
 
   await page.route(/.*\/rest\/v1\/transactions.*/, async (route) => {
     if (route.request().method() === "POST") transactionWritten = true;
     return route.fallback();
   });
-  await page.route(/.*\/rest\/v1\/plan_debt_terms.*/, async (route) => {
-    if (route.request().method() === "POST") {
-      newTermsBody = route.request().postDataJSON() as Record<string, unknown>;
-    }
-    return route.fallback();
-  });
-  await page.route(/.*\/rest\/v1\/plans.*/, async (route) => {
-    const request = route.request();
-    const method = request.method();
-    if (method === "POST") {
-      newPlanBody = request.postDataJSON() as Record<string, unknown>;
-      return route.fulfill({ status: 201, json: { id: "plan-refi-new" } });
-    }
-    if (method === "PATCH" && request.url().includes("id=eq.plan-debt-1")) {
-      oldPatchBody = request.postDataJSON() as Record<string, unknown>;
-      return route.fulfill({ status: 200, json: [{ id: "plan-debt-1" }] });
-    }
-    return route.fallback();
+  // Refinance is now a single atomic RPC; assert against its one request body.
+  await page.route(/.*\/rest\/v1\/rpc\/refinance_debt_plan.*/, async (route) => {
+    rpcBody = route.request().postDataJSON() as Record<string, unknown>;
+    return route.fulfill({ status: 200, json: "plan-refi-new" });
   });
 
   await page.goto("/plans/plan-debt-1");
@@ -206,16 +190,11 @@ test("refinances a debt plan: closes old, opens new, writes no transaction", asy
   await page.getByLabel("Rata miesięczna", { exact: true }).fill("2255.01");
   await page.getByRole("button", { name: "Otwórz nowy kredyt" }).click();
 
-  await expect.poll(() => newPlanBody?.refinanced_from_plan_id).toBe("plan-debt-1");
-  expect(newPlanBody?.kind).toBe("debt");
-  expect(newPlanBody?.status).toBe("active");
-  expect(Number(newPlanBody?.target_amount)).toBe(207000);
-
-  await expect.poll(() => newTermsBody?.monthly_payment).toBe(2255.01);
-  expect(Number(newTermsBody?.annual_rate)).toBe(5.96);
-
-  await expect.poll(() => oldPatchBody?.status).toBe("refinanced");
-  expect(oldPatchBody?.replaced_by_plan_id).toBe("plan-refi-new");
+  await expect.poll(() => rpcBody?.p_old_plan_id).toBe("plan-debt-1");
+  expect(rpcBody?.p_name).toBe("Hipoteka refinansowana");
+  expect(Number(rpcBody?.p_target_amount)).toBe(207000);
+  expect(Number(rpcBody?.p_annual_rate)).toBe(5.96);
+  expect(Number(rpcBody?.p_monthly_payment)).toBe(2255.01);
 
   await expect.poll(() => page.url()).toContain("/plans/plan-refi-new");
   expect(transactionWritten).toBe(false);

--- a/apps/web-svelte/src/lib/services/plan-refinance.ts
+++ b/apps/web-svelte/src/lib/services/plan-refinance.ts
@@ -1,6 +1,7 @@
 import { supabase } from "$lib/supabase";
-import { upsertPlanDebtTerms } from "$lib/services/plan-debt";
-import type { Plan } from "$lib/types";
+import type { Database } from "$lib/supabase.types";
+
+type RefinanceRpcArgs = Database["public"]["Functions"]["refinance_debt_plan"]["Args"];
 
 /** Fields the user enters in the refinance form. The parent fills in identity/scope. */
 export interface RefinanceFormInput {
@@ -21,82 +22,55 @@ export interface RefinanceInput extends RefinanceFormInput {
   categoryId: string | null;
 }
 
-export interface RefinancePlanRows {
-  newPlan: Pick<
-    Plan,
-    | "name"
-    | "user_id"
-    | "group_id"
-    | "category_id"
-    | "kind"
-    | "target_amount"
-    | "start_date"
-    | "end_date"
-    | "status"
-    | "refinanced_from_plan_id"
-  >;
-  newTerms: {
-    original_amount: number;
-    current_balance: number;
-    annual_rate: number;
-    monthly_payment: number;
-    first_payment_date: string;
-    first_payment_amount: number | null;
-  };
-  oldPatch: { status: "refinanced"; replaced_by_plan_id: string };
+/** Named arguments for the `refinance_debt_plan` Postgres RPC. */
+export interface RefinanceRpcParams {
+  p_old_plan_id: string;
+  p_name: string;
+  p_group_id: string | null;
+  p_category_id: string | null;
+  p_target_amount: number;
+  p_start_date: string;
+  p_end_date: string;
+  p_annual_rate: number;
+  p_monthly_payment: number;
+  p_first_payment_date: string;
+  p_first_payment_amount: number | null;
 }
 
-/** Pure mapping from refinance input to the rows we will persist. Testable without a DB. */
-export function buildRefinancePlans(input: RefinanceInput, newPlanId: string): RefinancePlanRows {
+/**
+ * Pure mapping from refinance form input to the RPC arguments. Testable without a DB.
+ * `user_id` is intentionally omitted: the RPC sets it to `auth.uid()` server-side so
+ * the new plan can never be created under another user's identity.
+ */
+export function buildRefinanceRpcParams(input: RefinanceInput): RefinanceRpcParams {
   return {
-    newPlan: {
-      name: input.newName,
-      user_id: input.userId,
-      group_id: input.groupId,
-      category_id: input.categoryId,
-      kind: "debt",
-      target_amount: input.originalAmount,
-      start_date: input.disbursementDate,
-      end_date: input.endDate,
-      status: "active",
-      refinanced_from_plan_id: input.oldPlanId,
-    },
-    newTerms: {
-      original_amount: input.originalAmount,
-      current_balance: input.originalAmount,
-      annual_rate: input.annualRate,
-      monthly_payment: input.monthlyPayment,
-      first_payment_date: input.firstPaymentDate,
-      first_payment_amount: input.firstPaymentAmount,
-    },
-    oldPatch: { status: "refinanced", replaced_by_plan_id: newPlanId },
+    p_old_plan_id: input.oldPlanId,
+    p_name: input.newName,
+    p_group_id: input.groupId,
+    p_category_id: input.categoryId,
+    p_target_amount: input.originalAmount,
+    p_start_date: input.disbursementDate,
+    p_end_date: input.endDate,
+    p_annual_rate: input.annualRate,
+    p_monthly_payment: input.monthlyPayment,
+    p_first_payment_date: input.firstPaymentDate,
+    p_first_payment_amount: input.firstPaymentAmount,
   };
 }
 
 /**
- * Execute a refinance: create the new debt plan + terms, archive the old plan, link both.
- * No transactions are written (the cash wash nets zero). Rolls back the new plan if terms fail.
+ * Execute a refinance atomically via the `refinance_debt_plan` RPC: it creates the
+ * new active debt plan + terms and archives the old plan in a single transaction, so
+ * an interrupted client can never leave both the old and new loans active (which would
+ * double-count the debt). No transactions are written (the cash wash nets to zero).
  */
 export async function refinanceDebtPlan(input: RefinanceInput): Promise<{ newPlanId: string }> {
-  const draft = buildRefinancePlans(input, "");
-  const { data: created, error: createErr } = await supabase
-    .from("plans")
-    .insert(draft.newPlan)
-    .select("id")
-    .single();
-  if (createErr) throw createErr;
-  const newPlanId = (created as { id: string }).id;
-
-  try {
-    await upsertPlanDebtTerms(newPlanId, { ...draft.newTerms });
-    const { error: patchErr } = await supabase
-      .from("plans")
-      .update({ status: "refinanced", replaced_by_plan_id: newPlanId })
-      .eq("id", input.oldPlanId);
-    if (patchErr) throw patchErr;
-  } catch (err) {
-    await supabase.from("plans").delete().eq("id", newPlanId);
-    throw err;
-  }
-  return { newPlanId };
+  // Nullable uuid/numeric RPC args (group_id, category_id, first_payment_amount) are
+  // valid as null at runtime; the generated Args type models them as non-null, so cast.
+  const { data, error } = await supabase.rpc(
+    "refinance_debt_plan",
+    buildRefinanceRpcParams(input) as RefinanceRpcArgs
+  );
+  if (error) throw error;
+  return { newPlanId: data as string };
 }

--- a/apps/web-svelte/src/lib/services/plan-settlement.ts
+++ b/apps/web-svelte/src/lib/services/plan-settlement.ts
@@ -567,6 +567,11 @@ export async function fetchDashboardPlanProgress(limit = 8): Promise<PlanSettlem
   const { data: plans, error } = await supabase
     .from("plans")
     .select("*")
+    // Only active plans: a refinanced/closed debt whose end_date is still in the
+    // future must not keep showing on the dashboard (it would double-count against
+    // the live replacement). Mirrors isLivePlan (status === 'active') used by the
+    // net-worth and obligation surfaces.
+    .eq("status", "active")
     .gte("end_date", new Date().toISOString().slice(0, 10))
     .order("start_date", { ascending: true })
     .limit(limit);

--- a/apps/web-svelte/src/lib/supabase.types.ts
+++ b/apps/web-svelte/src/lib/supabase.types.ts
@@ -1124,6 +1124,22 @@ export type Database = {
       privacy_mask_text: { Args: { p_label: string }; Returns: string };
       process_bank_import_reminders: { Args: never; Returns: undefined };
       process_recurring_transactions: { Args: never; Returns: undefined };
+      refinance_debt_plan: {
+        Args: {
+          p_annual_rate: number;
+          p_category_id: string;
+          p_end_date: string;
+          p_first_payment_amount: number;
+          p_first_payment_date: string;
+          p_group_id: string;
+          p_monthly_payment: number;
+          p_name: string;
+          p_old_plan_id: string;
+          p_start_date: string;
+          p_target_amount: number;
+        };
+        Returns: string;
+      };
       reject_invitation: {
         Args: { p_invitation_id: string };
         Returns: undefined;

--- a/apps/web-svelte/tests/rls/refinance_debt_plan.spec.ts
+++ b/apps/web-svelte/tests/rls/refinance_debt_plan.spec.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SENTINEL, cleanupSentinels, provisionTwoUsers, type TestContext } from "./setup";
+
+/**
+ * Functional coverage for the atomic refinance RPC. The point of moving refinance
+ * into one Postgres transaction is that it can never leave the old loan active while
+ * the replacement is also active (double-count), and that a caller cannot refinance a
+ * plan they do not manage. Both are asserted here against real RLS.
+ */
+describe("RPC: refinance_debt_plan (atomic)", () => {
+  let ctx: TestContext;
+  let oldPlanId: string;
+
+  async function seedActiveDebtPlan(name: string, target = 200000): Promise<string> {
+    const { data, error } = await ctx.userA.client
+      .from("plans")
+      .insert({
+        name,
+        user_id: ctx.userA.userId,
+        kind: "debt",
+        target_amount: target,
+        start_date: "2026-01-01",
+        end_date: "2036-01-01",
+        status: "active",
+      })
+      .select("id")
+      .single();
+    if (error) throw error;
+    const planId = (data as { id: string }).id;
+    const { error: termsErr } = await ctx.userA.client.from("plan_debt_terms").insert({
+      plan_id: planId,
+      original_amount: target,
+      current_balance: target,
+      annual_rate: 6,
+      monthly_payment: 2000,
+    });
+    if (termsErr) throw termsErr;
+    return planId;
+  }
+
+  const refiArgs = (oldId: string, name: string) => ({
+    p_old_plan_id: oldId,
+    p_name: name,
+    p_group_id: null,
+    p_category_id: null,
+    p_target_amount: 207000,
+    p_start_date: "2026-06-12",
+    p_end_date: "2036-10-10",
+    p_annual_rate: 5.96,
+    p_monthly_payment: 2255.01,
+    p_first_payment_date: "2026-08-10",
+    p_first_payment_amount: null,
+  });
+
+  beforeAll(async () => {
+    ctx = await provisionTwoUsers();
+    await cleanupSentinels(ctx.admin);
+    oldPlanId = await seedActiveDebtPlan(`${SENTINEL} refi old`);
+  });
+
+  afterAll(async () => {
+    await cleanupSentinels(ctx.admin);
+  });
+
+  it("archives the old plan and creates a new active linked plan + terms in one call", async () => {
+    const { data: newId, error } = await ctx.userA.client.rpc(
+      "refinance_debt_plan",
+      refiArgs(oldPlanId, `${SENTINEL} refi new`),
+    );
+    expect(error).toBeNull();
+    expect(typeof newId).toBe("string");
+
+    const { data: oldPlan } = await ctx.userA.client
+      .from("plans")
+      .select("status, replaced_by_plan_id")
+      .eq("id", oldPlanId)
+      .single();
+    expect(oldPlan?.status).toBe("refinanced");
+    expect(oldPlan?.replaced_by_plan_id).toBe(newId);
+
+    const { data: newPlan } = await ctx.userA.client
+      .from("plans")
+      .select("status, kind, refinanced_from_plan_id")
+      .eq("id", newId as string)
+      .single();
+    expect(newPlan?.status).toBe("active");
+    expect(newPlan?.kind).toBe("debt");
+    expect(newPlan?.refinanced_from_plan_id).toBe(oldPlanId);
+
+    const { data: newTerms } = await ctx.userA.client
+      .from("plan_debt_terms")
+      .select("monthly_payment, current_balance")
+      .eq("plan_id", newId as string)
+      .single();
+    expect(Number(newTerms?.monthly_payment)).toBe(2255.01);
+    expect(Number(newTerms?.current_balance)).toBe(207000);
+  });
+
+  it("rolls back entirely when the old plan is already refinanced (status guard)", async () => {
+    const before = await ctx.userA.client
+      .from("plans")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", ctx.userA.userId);
+
+    // oldPlanId is now 'refinanced' from the previous test → guard raises.
+    const { error } = await ctx.userA.client.rpc(
+      "refinance_debt_plan",
+      refiArgs(oldPlanId, `${SENTINEL} refi dup`),
+    );
+    expect(error).not.toBeNull();
+
+    const after = await ctx.userA.client
+      .from("plans")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", ctx.userA.userId);
+    expect(after.count).toBe(before.count); // no orphan plan created
+
+    const { data: dup } = await ctx.userA.client
+      .from("plans")
+      .select("id")
+      .eq("name", `${SENTINEL} refi dup`);
+    expect(dup?.length ?? 0).toBe(0);
+  });
+
+  it("user B cannot refinance user A's plan (cross-user write rolls back)", async () => {
+    const aPlanId = await seedActiveDebtPlan(`${SENTINEL} refi A2`, 100000);
+
+    // B's new-plan insert sets user_id = B (auth.uid()), so it would succeed on its own,
+    // but the old-plan UPDATE matches 0 rows under B's RLS → NOT FOUND → raise → full rollback.
+    const { error } = await ctx.userB.client.rpc(
+      "refinance_debt_plan",
+      refiArgs(aPlanId, `${SENTINEL} refi B-steal`),
+    );
+    expect(error).not.toBeNull();
+
+    // A's plan is untouched.
+    const { data: aPlan } = await ctx.userA.client
+      .from("plans")
+      .select("status")
+      .eq("id", aPlanId)
+      .single();
+    expect(aPlan?.status).toBe("active");
+
+    // No partial B plan persisted.
+    const { data: stolen } = await ctx.userB.client
+      .from("plans")
+      .select("id")
+      .eq("name", `${SENTINEL} refi B-steal`);
+    expect(stolen?.length ?? 0).toBe(0);
+  });
+});

--- a/apps/web-svelte/tests/unit/plan-refinance.spec.ts
+++ b/apps/web-svelte/tests/unit/plan-refinance.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("$lib/supabase", () => ({ supabase: {} }));
 
-import { buildRefinancePlans, type RefinanceInput } from "$lib/services/plan-refinance";
+import { buildRefinanceRpcParams, type RefinanceInput } from "$lib/services/plan-refinance";
 
 const input: RefinanceInput = {
   oldPlanId: "old-1",
@@ -19,26 +19,37 @@ const input: RefinanceInput = {
   firstPaymentAmount: 3115.38,
 };
 
-describe("buildRefinancePlans", () => {
-  it("maps the new plan row as an active debt plan linking the old one", () => {
-    const { newPlan } = buildRefinancePlans(input, "new-1");
-    expect(newPlan.kind).toBe("debt");
-    expect(newPlan.status).toBe("active");
-    expect(newPlan.refinanced_from_plan_id).toBe("old-1");
-    expect(newPlan.start_date).toBe("2026-06-12");
-    expect(newPlan.user_id).toBe("u-1");
+describe("buildRefinanceRpcParams", () => {
+  it("maps the form input to the refinance_debt_plan RPC arguments", () => {
+    const params = buildRefinanceRpcParams(input);
+    expect(params.p_old_plan_id).toBe("old-1");
+    expect(params.p_name).toBe("Hipoteka 2026 (refinansowanie)");
+    expect(params.p_target_amount).toBe(173000);
+    expect(params.p_start_date).toBe("2026-06-12");
+    expect(params.p_end_date).toBe("2036-10-10");
+    expect(params.p_annual_rate).toBe(5.96);
+    expect(params.p_monthly_payment).toBe(2255.01);
   });
 
-  it("maps the new debt terms with the explicit first installment", () => {
-    const { newTerms } = buildRefinancePlans(input, "new-1");
-    expect(newTerms.first_payment_amount).toBe(3115.38);
-    expect(newTerms.first_payment_date).toBe("2026-08-10");
-    expect(newTerms.current_balance).toBe(173000);
+  it("carries the explicit first installment through", () => {
+    const params = buildRefinanceRpcParams(input);
+    expect(params.p_first_payment_date).toBe("2026-08-10");
+    expect(params.p_first_payment_amount).toBe(3115.38);
   });
 
-  it("maps the old-plan archive patch", () => {
-    const { oldPatch } = buildRefinancePlans(input, "new-1");
-    expect(oldPatch.status).toBe("refinanced");
-    expect(oldPatch.replaced_by_plan_id).toBe("new-1");
+  it("omits user_id (the RPC sets it to auth.uid() server-side)", () => {
+    const params = buildRefinanceRpcParams(input) as unknown as Record<string, unknown>;
+    expect("p_user_id" in params).toBe(false);
+    expect("user_id" in params).toBe(false);
+  });
+
+  it("passes group + category scope straight through", () => {
+    const params = buildRefinanceRpcParams({
+      ...input,
+      groupId: "g-1",
+      categoryId: "c-1",
+    });
+    expect(params.p_group_id).toBe("g-1");
+    expect(params.p_category_id).toBe("c-1");
   });
 });

--- a/supabase/migrations/20260713000000_refinance_debt_plan_rpc.sql
+++ b/supabase/migrations/20260713000000_refinance_debt_plan_rpc.sql
@@ -1,0 +1,85 @@
+-- 20260713000000_refinance_debt_plan_rpc.sql
+-- Make refinance atomic. Previously the client ran three separate requests
+-- (insert new plan -> insert terms -> archive old plan); an interruption between
+-- them could leave the replacement active WHILE the old loan stayed active,
+-- double-counting the debt until manual cleanup. This wraps all three writes in
+-- one transaction so it is all-or-nothing.
+--
+-- SECURITY INVOKER (default): every write is still enforced by the existing
+-- plans / plan_debt_terms RLS policies under the caller's role, exactly like the
+-- old direct-table path -- this only adds atomicity, no privilege change. The new
+-- plan + terms are fresh inserts, so the partial-upsert "preserve first-payment"
+-- logic in upsertPlanDebtTerms does not apply here.
+
+create or replace function public.refinance_debt_plan(
+  p_old_plan_id         uuid,
+  p_name                text,
+  p_group_id            uuid,
+  p_category_id         uuid,
+  p_target_amount       numeric,
+  p_start_date          date,
+  p_end_date            date,
+  p_annual_rate         numeric,
+  p_monthly_payment     numeric,
+  p_first_payment_date  date,
+  p_first_payment_amount numeric
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_new_id uuid;
+begin
+  -- 1. New active debt plan, owned by the caller, linked back to the old loan.
+  insert into public.plans (
+    name, user_id, group_id, category_id, kind, target_amount,
+    start_date, end_date, status, refinanced_from_plan_id
+  ) values (
+    p_name, auth.uid(), p_group_id, p_category_id, 'debt', p_target_amount,
+    p_start_date, p_end_date, 'active', p_old_plan_id
+  )
+  returning id into v_new_id;
+
+  -- 2. Fresh debt terms for the new plan (balance anchored at disbursement today,
+  --    matching the upsertPlanDebtTerms fresh-insert behaviour).
+  insert into public.plan_debt_terms (
+    plan_id, original_amount, current_balance, annual_rate, monthly_payment,
+    anchor_balance, balance_anchor_date, first_payment_date, first_payment_amount
+  ) values (
+    v_new_id, p_target_amount, p_target_amount, p_annual_rate, p_monthly_payment,
+    p_target_amount, current_date, p_first_payment_date, p_first_payment_amount
+  );
+
+  -- 3. Archive the old loan and link the replacement. Guard on status = 'active'
+  --    so a non-manageable id, a wrong id, or a double-refinance race matches no
+  --    row and aborts the whole transaction (rolling back steps 1 and 2).
+  update public.plans
+     set status = 'refinanced', replaced_by_plan_id = v_new_id
+   where id = p_old_plan_id
+     and status = 'active';
+
+  if not found then
+    raise exception 'refinance_debt_plan: old plan % not active or not manageable', p_old_plan_id
+      using errcode = 'check_violation';
+  end if;
+
+  return v_new_id;
+end;
+$$;
+
+comment on function public.refinance_debt_plan(
+  uuid, text, uuid, uuid, numeric, date, date, numeric, numeric, date, numeric
+) is
+  'Atomic debt refinance: creates the new active debt plan + terms, archives the old plan (status=refinanced, replaced_by_plan_id), all in one transaction. Writes no transactions (cash wash nets to zero). RLS-enforced (SECURITY INVOKER).';
+
+revoke all on function public.refinance_debt_plan(
+  uuid, text, uuid, uuid, numeric, date, date, numeric, numeric, date, numeric
+) from public;
+revoke all on function public.refinance_debt_plan(
+  uuid, text, uuid, uuid, numeric, date, date, numeric, numeric, date, numeric
+) from anon;
+grant execute on function public.refinance_debt_plan(
+  uuid, text, uuid, uuid, numeric, date, date, numeric, numeric, date, numeric
+) to authenticated;


### PR DESCRIPTION
## Why

Two P2 gaps in the debt-engine/refinance work (surfaced on #148):

1. **Refinance was not atomic.** The client ran three separate requests (insert new plan → insert terms → archive old plan). An interruption after the new-plan insert but before the old-plan archive left the replacement **and** the old loan both `active`, double-counting the debt until manual cleanup. The `catch` only rolled back on a thrown error, not on a tab close / network drop.
2. **Dashboard progress ignored plan status.** `fetchDashboardPlanProgress` filtered only by `end_date`, so a refinanced/closed debt with a future `end_date` kept showing on the dashboard and double-counted against the live replacement.

## What

- **Atomic refinance RPC** (`migration 20260713000000`): `refinance_debt_plan(...)` — `SECURITY INVOKER` plpgsql, all three writes in one transaction. RLS still enforces every write under the caller's role (no privilege change). A `status='active'` guard on the old-plan UPDATE raises → full rollback when the id is not active or not manageable, which also blocks cross-user refinance. `plan-refinance.ts` now calls the RPC via a pure, unit-tested param builder; the old client sequence + `buildRefinancePlans` are removed. Writes no transactions (cash wash nets zero).
- **Dashboard status filter:** `fetchDashboardPlanProgress` gains `.eq("status","active")`, mirroring `isLivePlan` used by net-worth/obligation surfaces, so all debt surfaces agree.

## Tests / gates

- New RLS spec `refinance_debt_plan.spec.ts`: archive+create, status-guard rollback, **cross-user rollback** (B's new plan never persists; A's plan stays active).
- Refinance E2E rewritten to assert the single RPC request body + still asserts no `/transactions` POST.
- svelte-check 0/0, lint 0 errors (5 pre-existing generated-paraglide warnings), format clean, unit 224/224, RLS 269/269, plans E2E 7/7, plan-settle E2E 6/6, secret scan clean.

## Notes

- Migration applied locally only; needs the usual staging→prod apply.
- The CI "Real-DB smoke" failure on #148 was a staging flake (rerun green; create-transaction toast timeout, unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
