### PR TITLE
fix(transactions): drop duplicate quick-view pills (#155)

### DIFF
--- a/apps/web-svelte/messages/pl.json
+++ b/apps/web-svelte/messages/pl.json
@@ -105,6 +105,7 @@
   "transactions_view_unlinked": "Bez planu",
   "transactions_view_inne": "Inne",
   "transactions_view_month": "Ten miesiąc",
+  "transactions_view_quick": "Szybkie filtry",
   "transactions_status_draft": "Szkic",
   "transactions_status_upcoming": "Nadchodzące",
   "transactions_status_overdue": "Zaległe",

--- a/apps/web-svelte/src/lib/services/net-worth-items.ts
+++ b/apps/web-svelte/src/lib/services/net-worth-items.ts
@@ -55,8 +55,13 @@ export async function saveNetWorthItems(items: NetWorthItemInput[]): Promise<voi
 
   if (cleaned.length === 0) return;
 
+  // Generate ids client-side for new rows so every payload row has the same
+  // columns. A mixed bulk upsert (some rows with id, some without) makes PostgREST
+  // send `id: null` for the id-less rows instead of applying the column default,
+  // which violates the NOT NULL primary key. Uniform columns avoid that; existing
+  // rows still update on their id, new rows insert with a fresh uuid.
   const payload = cleaned.map((i, idx) => ({
-    ...(i.id ? { id: i.id } : {}),
+    id: i.id ?? crypto.randomUUID(),
     user_id: user.id,
     label: i.label.trim().slice(0, 60),
     amount: Math.max(0, i.amount),

--- a/apps/web-svelte/src/routes/transactions/+page.svelte
+++ b/apps/web-svelte/src/routes/transactions/+page.svelte
@@ -589,32 +589,6 @@
     goto(`/transactions?${p.toString()}`, { replaceState: false });
   }
 
-  function applyAllPreset() {
-    const p = new URLSearchParams($page.url.searchParams);
-    p.delete("type");
-    p.delete("status");
-    p.delete("categoryId");
-    p.delete("view");
-    searchQuery = "";
-    goto(`/transactions?${p.toString()}`, { replaceState: false });
-  }
-
-  function applyMonthPreset() {
-    const p = new URLSearchParams($page.url.searchParams);
-    const cy = now.getFullYear();
-    const cm = now.getMonth() + 1;
-    p.set("startYear", String(cy));
-    p.set("startMonth", String(cm));
-    p.set("endYear", String(cy));
-    p.set("endMonth", String(cm));
-    p.delete("startDate");
-    p.delete("endDate");
-    goto(`/transactions?${p.toString()}`, { replaceState: false });
-  }
-
-  // A preset chip is "active" when its slice of the URL state currently holds.
-  const isAllPresetActive = $derived(!viewFilter && !typeFilter && !statusFilter && !categoryId);
-
   const statusLabels: Record<string, string> = {
     paid: m.transactions_status_paid(),
     upcoming: m.transactions_status_upcoming(),
@@ -865,8 +839,8 @@
     </div>
   {/if}
 
-  <div class="flex flex-wrap gap-2" role="group" aria-label={m.transactions_view_all()}>
-    {#each [{ key: "all", label: m.transactions_view_all(), active: isAllPresetActive, run: applyAllPreset }, { key: "unlinked", label: m.transactions_view_unlinked(), active: viewFilter === "unlinked", run: () => setViewPreset("unlinked") }, { key: "inne", label: m.transactions_view_inne(), active: viewFilter === "inne", run: () => setViewPreset("inne") }, { key: "month", label: m.transactions_view_month(), active: isDefaultDateFilter, run: applyMonthPreset }] as preset (preset.key)}
+  <div class="flex flex-wrap gap-2" role="group" aria-label={m.transactions_view_quick()}>
+    {#each [{ key: "unlinked", label: m.transactions_view_unlinked(), active: viewFilter === "unlinked", run: () => setViewPreset("unlinked") }, { key: "inne", label: m.transactions_view_inne(), active: viewFilter === "inne", run: () => setViewPreset("inne") }] as preset (preset.key)}
       <button
         type="button"
         aria-pressed={preset.active}


### PR DESCRIPTION
* fix(net-worth): generate item ids client-side to avoid null-id insert

Adding a net-worth item alongside existing ones failed on production with "null value in column id violates not-null constraint". The bulk upsert sent a mixed array (existing rows with id, new rows without), so PostgREST filled the missing id with null instead of applying the column default. Generate a uuid client-side for new rows so every payload row has uniform columns: existing rows still update on their id, new rows insert with a fresh uuid.



* fix(transactions): drop duplicate quick-view pills

The quick-view row duplicated existing controls: its "Wszystkie" pill mirrored the group-scope "Wszystkie" tab (two identical green pills stacked) and its "Ten miesiąc" pill mirrored the date-range chip. Keep only the genuinely new quick filters (Bez planu / Inne, which toggle off on re-tap) and relabel the row group. Removes the now-unused applyAllPreset/applyMonthPreset/ isAllPresetActive helpers.



---------

<!--
Prefer the automation: run `scripts/open-pr.sh` (or the `/pr` command) - it runs all
gates and fills this body for you. This stub is only a fallback for hand-opened PRs.
-->

## Summary

-

## Why

-
