### PR TITLE
fix(smoke): select category by exact option name to avoid create-affo…

### DIFF
--- a/apps/web-svelte/e2e/smoke/transactions.smoke.spec.ts
+++ b/apps/web-svelte/e2e/smoke/transactions.smoke.spec.ts
@@ -42,13 +42,20 @@ test('login + create + read + delete transaction against real Supabase', async (
 
   // Category is a searchable combobox (not a native select). Wait for the
   // seeded category to load via TanStack Query, then pick it from the listbox.
+  // `exact: true` is essential: the create affordance ("Dodaj „<name>”") contains
+  // the category name as a substring, so a non-exact match can resolve to the
+  // create option while the categories query is still loading - selecting it would
+  // POST a duplicate category (409) and leave the transaction without a category.
+  // Exact match targets only the real option and waits for the list to populate.
   const categoryInput = page.locator('#tx-cat');
   await categoryInput.click();
   await categoryInput.fill(categoryName);
-  await expect(page.getByRole('option', { name: categoryName })).toBeVisible({
+  await expect(
+    page.getByRole('option', { name: categoryName, exact: true }),
+  ).toBeVisible({
     timeout: 10000,
   });
-  await page.getByRole('option', { name: categoryName }).click();
+  await page.getByRole('option', { name: categoryName, exact: true }).click();
 
   await page.getByRole('button', { name: 'Zapisz' }).click();
 


### PR DESCRIPTION
…rdance race

The staging smoke intermittently failed creating a transaction: no "Transakcja dodana" toast, with a 409 on POST /categories in the logs. Root cause: the category combobox shows a "Dodaj „<name>”" create affordance while the seeded category is still loading. The test's getByRole('option', { name: categoryName }) matched that create option by substring, so during the load race it clicked "create" instead of selecting the existing category - POSTing a duplicate category (409, unique constraint), leaving the transaction without a category and the save failing.

Use { exact: true } so the locator only ever matches the real category option (the create label is "Dodaj „<name>”", not the bare name) and toBeVisible waits for the categories query to populate before clicking.

<!--
Prefer the automation: run `scripts/open-pr.sh` (or the `/pr` command) - it runs all
gates and fills this body for you. This stub is only a fallback for hand-opened PRs.
-->

## Summary

-

## Why

-
