### PR TITLE
Merge branch 'main' of github.com:adrianghub/portfelik into dev

### DIFF
--- a/apps/web-svelte/e2e/tests/cash-position.spec.ts
+++ b/apps/web-svelte/e2e/tests/cash-position.spec.ts
@@ -72,10 +72,6 @@ const CASH_TXS = [
 const desktopTable = (page: Page) => page.locator("table");
 const strip = (page: Page) => page.getByRole("region", { name: "Gotówka" });
 
-// Saldo cell of a given row (last cell when the running-balance column shows).
-const saldoCell = (page: Page, description: string) =>
-  desktopTable(page).locator("tbody tr").filter({ hasText: description }).locator("td").last();
-
 const MOCK_GROUP = {
   id: "group-1",
   name: "Wspólny budżet",
@@ -105,36 +101,19 @@ async function mockCash(
   }
 }
 
-test("private scope: strip shows live total and the last paid row's running balance matches it", async ({
-  page,
-}) => {
+test("private scope: strip shows live total and forecast", async ({ page }) => {
   await mockCash(page);
   await page.goto("/transactions?group=own");
 
   // Strip renders the live cash position. It first paints the opening balance,
   // then settles to live once the paid-history query resolves, so wait for the
-  // settled value (auto-retrying) before capturing it for reuse below.
+  // settled value (auto-retrying).
   await expect(strip(page)).toBeVisible();
-  const liveLocator = strip(page).locator("p.text-2xl");
-  await expect(liveLocator).toHaveText(/1\D?300,00/); // 1000 + 500 − 200
-  const liveText = (await liveLocator.textContent())?.trim() ?? "";
+  await expect(strip(page).locator("p.text-2xl")).toHaveText(/1\D?300,00/); // 1000 + 500 − 200
 
   // Forecast (live + upcoming income) is surfaced faintly.
   await expect(strip(page).getByText(/prognoza/)).toBeVisible();
   await expect(strip(page).getByText(/1\D?600,00/)).toBeVisible();
-
-  // The running-balance column shows, and the latest paid row equals the live total.
-  await expect(desktopTable(page).getByText("Saldo", { exact: true })).toBeVisible();
-  const lastBalance = (await saldoCell(page, "Wydatek gotówkowy").textContent())?.trim() ?? "";
-  expect(lastBalance).toBe(liveText);
-
-  // The earlier paid row carries the intermediate balance (1000 + 500).
-  const firstBalance = (await saldoCell(page, "Wpłata gotówki").textContent())?.trim() ?? "";
-  expect(firstBalance).toMatch(/1\D?500,00/);
-
-  // Upcoming rows continue the same private-scope balance rather than falling
-  // back to an empty Saldo cell.
-  await expect(saldoCell(page, "Przyszły wpływ")).toHaveText(/1\D?600,00/);
 });
 
 test("solo user (no groups) sees the cash view in the default scope", async ({ page }) => {
@@ -144,11 +123,7 @@ test("solo user (no groups) sees the cash view in the default scope", async ({ p
   await page.goto("/transactions");
 
   await expect(strip(page)).toBeVisible();
-  await expect(desktopTable(page).getByText("Saldo", { exact: true })).toBeVisible();
-  // For solo users the cash view only engages once groupsQuery resolves (no groups),
-  // and the running-balance map fills after the paid-history query. Assert with
-  // auto-retry instead of a one-shot read, else we race the "—" placeholder.
-  await expect(saldoCell(page, "Wydatek gotówkowy")).toHaveText(/1\D?300,00/);
+  await expect(strip(page).locator("p.text-2xl")).toHaveText(/1\D?300,00/);
 });
 
 test("group user: mixed all scope hides the cash view, own scope shows it", async ({ page }) => {
@@ -158,23 +133,17 @@ test("group user: mixed all scope hides the cash view, own scope shows it", asyn
   await page.goto("/transactions?group=all");
   await expect(desktopTable(page).getByText("Wydatek gotówkowy")).toBeVisible();
   await expect(strip(page)).toHaveCount(0);
-  await expect(desktopTable(page).getByText("Saldo", { exact: true })).toHaveCount(0);
 
   // Switching to own scope brings the pool back.
   await page.goto("/transactions?group=own");
   await expect(strip(page)).toBeVisible();
-  await expect(desktopTable(page).getByText("Saldo", { exact: true })).toBeVisible();
 });
 
-test("private scope without an anchor: strip prompts to set a balance, no Saldo column", async ({
-  page,
-}) => {
+test("private scope without an anchor: strip prompts to set a balance", async ({ page }) => {
   await mockCash(page, { withAnchor: false });
   await page.goto("/transactions?group=own");
 
   await expect(desktopTable(page).getByText("Wydatek gotówkowy")).toBeVisible();
   // Strip still renders, but as a prompt — no fabricated total.
   await expect(strip(page).getByText(/Ustaw saldo początkowe/)).toBeVisible();
-  // The running-balance column stays hidden until an opening anchor exists.
-  await expect(desktopTable(page).getByText("Saldo", { exact: true })).toHaveCount(0);
 });

--- a/apps/web-svelte/e2e/tests/transactions.spec.ts
+++ b/apps/web-svelte/e2e/tests/transactions.spec.ts
@@ -149,7 +149,7 @@ test("far-future recurring forecast rows expose only scoped series actions", asy
 
   const row = desktopTable(page).locator("tbody tr").filter({ hasText: "Czynsz" });
   await expect(row).toBeVisible();
-  await expect(row.getByText("Cykliczne / Planowane")).toBeVisible();
+  await expect(row.getByLabel("cykliczna (prognoza)")).toBeVisible();
   await expect(row.getByRole("button", { name: "Oznacz jako zapłacone" })).toHaveCount(0);
 
   await row.click();
@@ -201,7 +201,7 @@ test("near-term recurring occurrence rows are manageable transactions", async ({
 
   const row = desktopTable(page).locator("tbody tr").filter({ hasText: "Czynsz" });
   await expect(row).toBeVisible();
-  await expect(row.getByText("Cykliczne")).toBeVisible();
+  await expect(row.getByLabel("cykliczna")).toBeVisible();
   await expect(row.getByRole("button", { name: "Oznacz jako zapłacone" })).toBeVisible();
 
   await row.click();

--- a/apps/web-svelte/src/lib/components/dashboard/DashboardSpendingInsight.svelte
+++ b/apps/web-svelte/src/lib/components/dashboard/DashboardSpendingInsight.svelte
@@ -17,26 +17,16 @@
     categoryHref: (categoryId: string | null) => string;
   } = $props();
 
-  // Cap the treemap so tiny slivers stay legible. Fold the tail into a neutral
-  // "Pozostałe" bucket only when it collapses 2+ categories — a single overflow
-  // stays named (and never collides with the real "Inne wydatki" category).
-  const TREEMAP_TOP = 8;
-  const treemapCategories = $derived.by<TreemapCategory[]>(() => {
-    const cats = insight.categories.filter((c) => c.total > 0);
-    const toTile = (c: (typeof cats)[number]): TreemapCategory => ({
-      categoryId: c.categoryId,
-      name: c.name,
-      total: c.total,
-      deltaPct: insight.isFirstPeriod ? null : c.deltaPct,
-    });
-    if (cats.length <= TREEMAP_TOP + 1) return cats.map(toTile);
-    const top = cats.slice(0, TREEMAP_TOP).map(toTile);
-    const restTotal = cats.slice(TREEMAP_TOP).reduce((s, c) => s + c.total, 0);
-    if (restTotal > 0) {
-      top.push({ categoryId: null, name: "Pozostałe", total: restTotal, deltaPct: null });
-    }
-    return top;
-  });
+  const treemapCategories = $derived.by<TreemapCategory[]>(() =>
+    insight.categories
+      .filter((c) => c.total > 0)
+      .map((c) => ({
+        categoryId: c.categoryId,
+        name: c.name,
+        total: c.total,
+        deltaPct: insight.isFirstPeriod ? null : c.deltaPct,
+      }))
+  );
 
   const vsPrevLabel = $derived(
     period === "week"

--- a/apps/web-svelte/src/lib/components/dashboard/charts/SpendHistoryChart.svelte
+++ b/apps/web-svelte/src/lib/components/dashboard/charts/SpendHistoryChart.svelte
@@ -153,7 +153,7 @@
         </svelte:fragment>
 
         <!-- Suppress the tooltip entirely for zero-total windows. -->
-        <svelte:fragment slot="tooltip" let:tooltip let:visibleSeries>
+        <svelte:fragment slot="tooltip" let:tooltip>
           {#if rowTotal(tooltip?.data) > 0}
             <!-- Anchor over the hovered bar (x="data") and clamp to the chart box
                  (contained="container") so the tooltip stops jumping to the window
@@ -174,19 +174,11 @@
                 {/if}
                 {String(data.label)}
               </Tooltip.Header>
-              <Tooltip.List>
-                {#each [...visibleSeries]
-                  .reverse()
-                  .filter((s) => (Number(data[s.key]) || 0) > 0) as s (s.key)}
-                  <Tooltip.Item
-                    label={s.label}
-                    value={Number(data[s.key]) || 0}
-                    format={(v: unknown) => formatCurrency(v as number)}
-                    color={s.color}
-                    valueAlign="right"
-                  />
-                {/each}
-              </Tooltip.List>
+              <!-- Period total only — the per-category list grew taller than the chart and
+                   spilled over the legend; the stacked segments + legend already convey the split. -->
+              <div class="mt-0.5 text-sm font-semibold text-slate-100 tabular-nums">
+                {formatCurrency(rowTotal(data))}
+              </div>
             </Tooltip.Root>
           {/if}
         </svelte:fragment>

--- a/apps/web-svelte/src/lib/components/plans/NetWorthHero.svelte
+++ b/apps/web-svelte/src/lib/components/plans/NetWorthHero.svelte
@@ -54,7 +54,7 @@
     aria-label={m.plans_net_worth_title()}
   >
     <div class="flex items-start justify-between gap-3">
-      <div>
+      <div class="min-w-0">
         <p class="text-eyebrow text-slate-400">{m.plans_net_worth_title()}</p>
         <p
           class={cn(
@@ -64,7 +64,24 @@
         >
           {formatCurrency(summary.netWorth)}
         </p>
-        <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+        {#if summary.asOfDate}
+          <p class="mt-2 text-xs text-slate-500">
+            {m.plans_net_worth_subtitle({ date: formatDate(summary.asOfDate) })}
+          </p>
+        {/if}
+      </div>
+      <div class="flex shrink-0 flex-col items-end gap-3">
+        {#if onedit}
+          <button
+            type="button"
+            onclick={onedit}
+            class="focus-visible:ring-accent rounded-full border border-white/10 p-2 text-slate-400 hover:bg-white/5 hover:text-slate-100 focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={m.plans_net_worth_edit()}
+          >
+            <Pencil size={16} aria-hidden="true" />
+          </button>
+        {/if}
+        <div class="flex flex-col items-end gap-1 text-sm">
           <span class="text-emerald-300 tabular-nums">
             {m.plans_net_worth_assets({ amount: formatCurrency(summary.totalAssets) })}
           </span>
@@ -74,22 +91,7 @@
             </span>
           {/if}
         </div>
-        {#if summary.asOfDate}
-          <p class="mt-2 text-xs text-slate-500">
-            {m.plans_net_worth_subtitle({ date: formatDate(summary.asOfDate) })}
-          </p>
-        {/if}
       </div>
-      {#if onedit}
-        <button
-          type="button"
-          onclick={onedit}
-          class="focus-visible:ring-accent shrink-0 rounded-full border border-white/10 p-2 text-slate-400 hover:bg-white/5 hover:text-slate-100 focus-visible:ring-2 focus-visible:outline-none"
-          aria-label={m.plans_net_worth_edit()}
-        >
-          <Pencil size={16} aria-hidden="true" />
-        </button>
-      {/if}
     </div>
 
     {#if assetSegments.length > 0 && stripTotal > 0}

--- a/apps/web-svelte/src/lib/components/transactions/DateRangePicker.svelte
+++ b/apps/web-svelte/src/lib/components/transactions/DateRangePicker.svelte
@@ -296,7 +296,10 @@
 
 <div class="relative shrink-0" data-date-range-picker>
   <div
-    class="flex h-9 items-center gap-1 rounded-full border border-white/10 bg-slate-900/60 pr-1 pl-3.5 text-sm text-slate-200 backdrop-blur"
+    class={cn(
+      "flex h-9 items-center gap-1 rounded-full border border-white/10 bg-slate-900/60 pl-3.5 text-sm text-slate-200 backdrop-blur",
+      clearable && onclear ? "pr-1" : "pr-3.5"
+    )}
   >
     <button
       type="button"

--- a/apps/web-svelte/src/lib/components/transactions/TransactionTable.svelte
+++ b/apps/web-svelte/src/lib/components/transactions/TransactionTable.svelte
@@ -23,10 +23,6 @@
     stickyHeaderTop?: string;
     /** responsive: cards on mobile, table on sm+; cards: card list at all breakpoints (e.g. search). */
     layout?: "responsive" | "cards";
-    /** When provided, renders a right-aligned "Saldo" column showing the running balance after each row. */
-    runningBalanceById?: Map<string, number>;
-    /** Forecast continuation for upcoming/projected rows in the private cash view. */
-    forecastBalanceById?: Map<string, number>;
   }
   let {
     transactions,
@@ -40,11 +36,7 @@
     stickyHeaderOffset,
     stickyHeaderTop,
     layout = "responsive",
-    runningBalanceById,
-    forecastBalanceById,
   }: Props = $props();
-
-  const showBalance = $derived(!!runningBalanceById || !!forecastBalanceById);
 
   type SortKey = "date" | "description" | "category" | "status" | "amount";
   type SortDirection = "asc" | "desc";
@@ -300,23 +292,18 @@
                   {:else}
                     {tx.description}
                   {/if}
-                  {#if tx.is_recurring}
-                    <span class="ml-1 text-xs text-slate-400" aria-label="cykliczna">↻</span>
-                  {/if}
                   {#if isProjected(tx)}
                     <span
-                      class="ml-1 inline-flex rounded-full border border-sky-400/20 bg-sky-400/10 px-1.5 py-0.5 text-[10px] font-normal text-sky-300"
+                      class="ml-1 text-xs text-sky-300/70"
                       title={m.transactions_projected_hint()}
+                      aria-label="cykliczna (prognoza)">↻</span
                     >
-                      {m.transactions_recurring()} / {m.transactions_projected_badge()}
-                    </span>
-                  {:else if isRecurringOccurrence(tx)}
+                  {:else if isRecurringOccurrence(tx) || tx.is_recurring}
                     <span
-                      class="ml-1 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-1.5 py-0.5 text-[10px] font-normal text-emerald-300"
+                      class="ml-1 text-xs text-slate-400"
                       title={m.transactions_recurring_occurrence_hint()}
+                      aria-label="cykliczna">↻</span
                     >
-                      {m.transactions_recurring()}
-                    </span>
                   {/if}
                   {#if isShared(tx)}
                     <span
@@ -463,13 +450,6 @@
                 {@render sortIndicator("amount")}
               </button>
             </th>
-            {#if showBalance}
-              <th scope="col" class="w-36 px-4 py-3 text-right">
-                <span class="text-eyebrow ml-auto inline-flex items-center text-slate-400">
-                  {m.transactions_col_balance()}
-                </span>
-              </th>
-            {/if}
           </tr>
         </thead>
         <tbody>
@@ -525,23 +505,18 @@
                 {:else}
                   <span class="block truncate">{tx.description}</span>
                 {/if}
-                {#if tx.is_recurring}
-                  <span class="ml-1 text-xs text-slate-400" aria-label="cykliczna">↻</span>
-                {/if}
                 {#if isProjected(tx)}
                   <span
-                    class="ml-1 inline-flex rounded-full border border-sky-400/20 bg-sky-400/10 px-1.5 py-0.5 text-[10px] font-normal text-sky-300"
+                    class="ml-1 text-xs text-sky-300/70"
                     title={m.transactions_projected_hint()}
+                    aria-label="cykliczna (prognoza)">↻</span
                   >
-                    {m.transactions_recurring()} / {m.transactions_projected_badge()}
-                  </span>
-                {:else if isRecurringOccurrence(tx)}
+                {:else if isRecurringOccurrence(tx) || tx.is_recurring}
                   <span
-                    class="ml-1 inline-flex rounded-full border border-emerald-400/20 bg-emerald-400/10 px-1.5 py-0.5 text-[10px] font-normal text-emerald-300"
+                    class="ml-1 text-xs text-slate-400"
                     title={m.transactions_recurring_occurrence_hint()}
+                    aria-label="cykliczna">↻</span
                   >
-                    {m.transactions_recurring()}
-                  </span>
                 {/if}
                 {#if isShared(tx)}
                   <span
@@ -593,17 +568,6 @@
               >
                 {tx.type === "income" ? "+" : "−"}{formatCurrency(tx.amount, tx.currency)}
               </td>
-              {#if showBalance}
-                {@const bal = runningBalanceById?.get(tx.id) ?? forecastBalanceById?.get(tx.id)}
-                <td
-                  class="px-4 py-3 text-right font-semibold whitespace-nowrap tabular-nums {tx.status ===
-                  'paid'
-                    ? 'text-slate-400'
-                    : 'text-slate-500 italic'}"
-                >
-                  {bal != null ? formatCurrency(bal) : "—"}
-                </td>
-              {/if}
             </tr>
           {/each}
         </tbody>

--- a/apps/web-svelte/src/routes/dashboard/+page.svelte
+++ b/apps/web-svelte/src/routes/dashboard/+page.svelte
@@ -411,6 +411,23 @@
     buildRecurringSeriesList(recurringTemplatesQuery.data ?? []).length
   );
 
+  // "See all upcoming" must span the whole forecast horizon, not the dashboard's
+  // selected period — upcoming/overdue rows sit in future months and a week-wide
+  // window would land on an empty range.
+  const upcomingHref = $derived.by(() => {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const end = forwardWindows.length
+      ? previousDateOnly(forwardWindows[forwardWindows.length - 1].end)
+      : toIsoDate(now);
+    const p = new URLSearchParams();
+    p.set("startDate", toIsoDate(start));
+    p.set("endDate", end);
+    p.set("group", groupFilter);
+    p.set("status", "upcoming,overdue");
+    return `/transactions?${p.toString()}`;
+  });
+
   function openTransaction(tx: TransactionWithCategory) {
     goto(transactionsHref({ status: tx.status }));
   }
@@ -617,17 +634,7 @@
 
   <!-- Status band -->
   <section class="mt-6">
-    <div class="mb-2 flex items-center justify-between gap-2">
-      <h2 class="text-sm font-medium text-slate-400">{m.dashboard_status_band()}</h2>
-      {#if activeRecurringCount > 0}
-        <a
-          href="/recurring"
-          class="hover:text-accent text-xs font-medium text-slate-400 transition-colors"
-        >
-          {m.recurring_entry()} ({activeRecurringCount})
-        </a>
-      {/if}
-    </div>
+    <h2 class="mb-2 text-sm font-medium text-slate-400">{m.dashboard_status_band()}</h2>
     <div class="grid gap-3 sm:grid-cols-2">
       <DashboardActions
         {userId}
@@ -643,16 +650,23 @@
 
   <!-- Upcoming / overdue -->
   <div>
-    <div class="mb-2 flex items-center justify-between">
+    <div class="mb-2 flex items-center justify-between gap-2">
       <p class="text-eyebrow text-slate-400">{m.dashboard_upcoming_title()}</p>
-      {#if upcomingTxs.length > 0}
-        <a
-          href={transactionsHref({ status: "upcoming,overdue" })}
-          class="text-accent hover:text-accent text-xs font-medium"
-        >
-          {m.dashboard_upcoming_see_all()}
-        </a>
-      {/if}
+      <div class="flex items-center gap-3">
+        {#if activeRecurringCount > 0}
+          <a
+            href="/recurring"
+            class="hover:text-accent text-xs font-medium text-slate-400 transition-colors"
+          >
+            {m.recurring_entry()} ({activeRecurringCount})
+          </a>
+        {/if}
+        {#if upcomingTxs.length > 0}
+          <a href={upcomingHref} class="text-accent hover:text-accent text-xs font-medium">
+            {m.dashboard_upcoming_see_all()}
+          </a>
+        {/if}
+      </div>
     </div>
 
     {#if txQuery.isPending}

--- a/apps/web-svelte/src/routes/transactions/+page.svelte
+++ b/apps/web-svelte/src/routes/transactions/+page.svelte
@@ -17,10 +17,8 @@
   import * as m from "$lib/paraglide/messages";
   import {
     fetchPrivateCashPosition,
-    forecastRunningBalances,
     forecastPosition,
     livePosition,
-    runningBalances,
   } from "$lib/services/cash-position";
   import { createCategory, fetchCategories } from "$lib/services/categories";
   import { makeCreateCategoryInline } from "$lib/category-create";
@@ -67,7 +65,7 @@
   } from "$lib/utils";
   import { createMutation, createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { onMount } from "svelte";
-  import { Plus, Search, X } from "lucide-svelte";
+  import { Plus, Repeat, Search, X } from "lucide-svelte";
   import { toast } from "svelte-sonner";
   import { toastError } from "$lib/toast-error";
   import QueryError from "$lib/components/ui/QueryError.svelte";
@@ -467,11 +465,6 @@
   );
   const showCashView = $derived(isPrivateScope || soloAllScope);
 
-  // Per-row running balance only once an opening anchor exists — otherwise the
-  // column would accumulate from 0 while the strip still asks to set a balance.
-  const runningBalanceById = $derived(
-    showCashView && cashAnchor ? runningBalances(cashAnchor, privatePaidTxs) : undefined
-  );
   // Filter-independent private projection for the cash forecast: the full
   // private template set over the window, deduped against the full private cash
   // history. Using the table-filtered projectedTxs would make the personal
@@ -498,11 +491,6 @@
       date: tx.date,
     }));
   });
-  const forecastBalanceById = $derived(
-    showCashView && cashAnchor
-      ? forecastRunningBalances(cashAnchor, [...privatePaidTxs, ...privateForecastProjectedTxs])
-      : undefined
-  );
   const cashForecast = $derived(
     forecastPosition(cashAnchor, [...privatePaidTxs, ...privateForecastProjectedTxs])
   );
@@ -785,6 +773,7 @@
     upcoming: m.transactions_status_upcoming(),
     draft: m.transactions_status_draft(),
     overdue: m.transactions_status_overdue(),
+    "upcoming,overdue": m.dashboard_upcoming_title(),
   };
 
   // Applied filters shown as removable chips below the toolbar (only when set).
@@ -900,9 +889,11 @@
     <div class="flex shrink-0 items-center gap-2">
       <a
         href="/recurring"
-        class="focus-visible:ring-accent hidden h-9 items-center gap-1.5 rounded-full border border-white/10 px-3.5 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:outline-none md:inline-flex"
+        class="focus-visible:ring-accent inline-flex h-9 items-center gap-1.5 rounded-full border border-white/10 px-3 text-sm font-medium text-slate-300 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:outline-none sm:px-3.5"
+        title={m.recurring_entry()}
       >
-        {m.recurring_entry()}
+        <Repeat size={16} aria-hidden="true" />
+        <span class="hidden sm:inline">{m.recurring_entry()}</span>
       </a>
       <button
         onclick={openAdd}
@@ -1101,8 +1092,6 @@
     <TransactionTable
       transactions={renderedTxs}
       {currentUserId}
-      {runningBalanceById}
-      {forecastBalanceById}
       canManage={txCanManage}
       emptyLabel={tableEmptyLabel}
       emptyHint={tableEmptyHint}


### PR DESCRIPTION
<!-- Auto-filled by scripts/open-pr.sh - do not hand-edit. -->
## Summary

- Merge branch 'main' of github.com:adrianghub/portfelik into dev
- refactor(transactions): drop Saldo column, single recurring marker, mobile entry
- fix(transactions): date pill right padding when not clearable
- fix(dashboard): upcoming see-all spans forecast horizon, relocate recurring link
- fix(dashboard): compact spend-history tooltip to period total
- refactor(dashboard): show all spending categories in treemap
- refactor(plans): balance net-worth hero header row

## Why

- - Remove the per-row Saldo running-balance column entirely (it rendered "—" on
-   most rows and added a stray empty column on forecast months). Drops the table
-   column, the page-level running/forecast balance derivations and now-unused
-   cash-position imports, and the E2E assertions. The GOTÓWKA + prognoza strip
-   stays as the single cash headline.
- - Collapse the recurring/projected/occurrence pills into one subtle ↻ marker
-   (sky tint = forecast, slate = real), disambiguated by tooltip.
- - Show the recurring entry on mobile: header link is icon-only below sm, icon
-   plus label from sm up (was desktop-only, leaving no mobile path to /recurring).
- - Label the combined "upcoming,overdue" status chip instead of printing the raw
-   comma string.
- Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
- Without the clear (×) button the trigger only had pr-1, cramping longer month
- labels against the edge. Pad pr-3.5 when there is no clear button.
- Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
- "Zobacz wszystko" reused the dashboard's selected period (a 7-day week window),
- but upcoming/overdue rows sit in future months, so the link landed on an empty
- range. New upcomingHref spans first-of-month through the forward forecast end.
- Also move the "Cykliczne (N)" entry out of the Status band header (where it read
- as a stray floating link) into the Nadchodzące i zaległe header.
- Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
- The per-category list grew taller than the chart and spilled over the legend
- on dense bars. Show the period total only; the stacked segments + legend
- already convey the category split, and clicking a bar drills into details.
- Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
- Drop the "Pozostałe" tail fold. The treemap's own label thresholds keep tiny
- slivers legible, and folding hid real categories behind a neutral bucket.
- Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
- The header was justify-between with the value block left and a lone pencil
- button far right, leaving a dead gap. Move the assets/debt stats into a right
- column under the edit button so the row reads as two balanced halves.
- Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Gates

- [x] `pnpm exec svelte-check --tsconfig ./tsconfig.json` is 0/0
- [x] `pnpm lint` is clean
- [x] `pnpm format:check` is clean
- [x] `pnpm test:unit` is green
- [x] RLS suite - not applicable (no schema/policy change)
- [x] Secret scan is clean

## Migrations

- [x] Not applicable

## Paraglide

- [x] Not applicable

## Branch Sync

- [x] Branch was synced from `origin/main` per `CLAUDE.md`