### PR TITLE
ci: fix production rebrand build env

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -110,6 +110,7 @@ jobs:
           PUBLIC_SUPABASE_URL: https://emqzcygfwcvbmhxhfkcc.supabase.co
           PUBLIC_SUPABASE_ANON_KEY: test-anon-key
           PUBLIC_VAPID_KEY: BHKoiccZwq3Y5Qw5dmFxVLJIA7w9zcSZkchPKWk-vxBeR421yieZW7gGxuluBBa6sRmpIsFXRSuFyRarLcdvqT4
+          PUBLIC_PLAUSIBLE_DOMAIN: ""
         run: pnpm build
 
       - name: Run Playwright tests
@@ -191,7 +192,7 @@ jobs:
             sleep 10
           done
           test "$status" = "200"
-          grep -q "Portfelik" /tmp/index.html
+          grep -q "JakStoimy" /tmp/index.html
 
       - name: Supabase backend reachable
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,9 @@ the in-app notification row with push as an optional channel.
 
 **Onboarding + instrumentation (2026-06-28, committed on `dev`):** Spec #1 newcomer path (checklist persistence, demo seed/clear, glossary sheet, empty CTAs), Spec #2 Plausible (`PUBLIC_PLAUSIBLE_DOMAIN`, milestone `trackOnce` hooks, privacy copy), Spec #3 coachmarks (`plans_hub`, `transactions_import`), plus JakStoimy app-visible rebrand (nav/PWA/titles; operator cutover checklist in `docs/specs/2026-06-28-jakstoimy-rebrand-cutover-checklist.md`). Gates: Paraglide compile, svelte-check 0/0, format clean, unit 353/353, changed-file secret scan clean (login password state only).
 
-**Immediate next step (2026-06-28):** operator sets `STAGING_PUBLIC_PLAUSIBLE_DOMAIN` / `PUBLIC_PLAUSIBLE_DOMAIN` GH secrets + Plausible custom-event goals; staging smoke; execute Spec #5 domain/OAuth cutover when ready. Next product increment: Capacitor Phase A (Spec #4). Deferred: group-scope cash position, dashboard slice 2, field-scoped search, AI prep.
+**Production deploy workflow fix (2026-06-28, local):** push run `28330322328` failed in mocked Playwright build because `deploy-production.yml` omitted `PUBLIC_PLAUSIBLE_DOMAIN` after Plausible landed; production deploy/probe were skipped. Fixed by adding an empty Plausible domain to the mocked build env and updating the read-only production smoke grep from `Portfelik` to `JakStoimy`. Local gates: `pnpm build` in `apps/web-svelte`, `git diff --check`.
+
+**Immediate next step (2026-06-28):** push/merge the production workflow fix to `main`, rerun/monitor Deploy production, then operator sets `STAGING_PUBLIC_PLAUSIBLE_DOMAIN` / `PUBLIC_PLAUSIBLE_DOMAIN` GH secrets + Plausible custom-event goals; staging smoke; execute Spec #5 domain/OAuth cutover when ready. Next product increment: Capacitor Phase A (Spec #4). Deferred: group-scope cash position, dashboard slice 2, field-scoped search, AI prep.
 
 **Open backlog:**
 


### PR DESCRIPTION
Provide an empty Plausible domain for the mocked production E2E build and update the read-only production smoke probe to look for the JakStoimy shell after the rebrand.

<!--
Prefer the automation: run `scripts/open-pr.sh` (or the `/pr` command) - it runs all
gates and fills this body for you. This stub is only a fallback for hand-opened PRs.
-->

## Summary

-

## Why

-
